### PR TITLE
Updated application versioning

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout/@v2
+      - name: Update Go Application version information
+        shell: pwsh
+        run : |
+          (Get-Content version/version.go).Replace("-version", ${{ steps.semvertag.outputs.tag }}) | Set-Content version/version.go
+          (Get-Content version/version.go).Replace("-build", $Env:GITHUB_RUN_NUMBER) | Set-Content version/version.go
       - name: Create Release
         id: createrelease
         uses: actions/create-release@v1

--- a/cmd/secondlevel.go
+++ b/cmd/secondlevel.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/version"
 )
 
 var createCmd = &cobra.Command{
@@ -14,7 +16,16 @@ var listCmd = &cobra.Command{
 	Short: "Sets the scope to list operations",
 }
 
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Displays the version of sumocli",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.AppName + " " + version.Version + " " + version.BuildVersion)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(createCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(versionCmd)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,8 +1,7 @@
 package version
 
 var (
-	AppName      string = "Sumocli"
-	Version      string = ""
-	BuildVersion string = ""
-	BuildTime    string = ""
+	AppName      string = "sumocli"
+	Version      string = "-version"
+	BuildVersion string = "-build"
 )


### PR DESCRIPTION
# Background

Users should be able to tell which version of the sumocli they are running, previously there was no way to to do this.

# Before

There was no way to determin what version a build was.

# After

A GitHub Action step was added to create a semver compliant tag. That tag is then added to the version/version.go file as well as the GitHub Action run number.

The `sumocli version` was added to display the version information.

Note: if someone compiles the application from source there will be placeholder values such as -version and -build, unless they change them manually.
