### PR TITLE
Security management support

### DIFF
--- a/.github/workflows/sumocli-build.yml
+++ b/.github/workflows/sumocli-build.yml
@@ -256,3 +256,22 @@ jobs:
           asset_path: ./sumocli.zip
           asset_name: sumocli-macos-arm64.zip
           asset_content_type: application/zip
+
+  create_octopus_release:
+    name: Create Octopus Release
+    needs: [create_semver, create_github_release, build_windows, build_linux, build_macos_intel, build_macos_apple_silicon]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Octopus CLI
+        uses: OctopusDeploy/install-octopus-cli-action@v1.1.6
+        with:
+          version: latest
+      - name: Create New Octopus Release
+        uses: OctopusDeploy/create-release-action@v1.0.2
+        with:
+          api_key: ${{ secrets.OCTOPUS_API_KEY }}
+          project: "Sumocli Release"
+          server: ${{ secrets.OCTOPUS_SERVER }}
+          variables:
+            version:${{ needs.create_semver.outputs.semvertag }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # sumocli
 A CLI application that lets you manage/automate your Sumo Logic tenancy. 
 
+Sumocli is currently in development so there could be bugs/incomplete functionality.
+GA will be v1.0.0 which I am expecting to be ready for release towards the end of 2021.
 ## Installation
 
 ### Recommended

--- a/api/account.go
+++ b/api/account.go
@@ -1,0 +1,14 @@
+package api
+
+type GetSubdomain struct {
+	CreatedAt  string `json:"createdAt"`
+	CreatedBy  string `json:"createdBy"`
+	ModifiedAt string `json:"modifiedAt"`
+	ModifiedBy string `json:"modifiedBy"`
+	Subdomain  string `json:"subdomain"`
+	URL        string `json:"url"`
+}
+
+type UpdateSubdomainRequest struct {
+	Subdomain string `json:"subdomain"`
+}

--- a/api/ingest-budgets-v2.go
+++ b/api/ingest-budgets-v2.go
@@ -1,0 +1,24 @@
+package api
+
+type GetIngestBudgetV2 struct {
+	Name           string `json:"name"`
+	Scope          string `json:"scope"`
+	CapacityBytes  int    `json:"capacityBytes"`
+	Timezone       string `json:"timezone"`
+	ResetTime      string `json:"resetTime"`
+	Description    string `json:"description"`
+	Action         string `json:"action"`
+	AuditThreshold int    `json:"auditThreshold"`
+	Id             string `json:"id"`
+	UsageBytes     int    `json:"usageBytes"`
+	UsageStatus    string `json:"usageStatus"`
+	CreatedAt      string `json:"createdAt"`
+	CreatedBy      string `json:"createdBy"`
+	ModifiedAt     string `json:"modifiedAt"`
+	ModifiedBy     string `json:"modifiedBy"`
+	BudgetVersion  int    `json:"budgetVersion"`
+}
+
+type ListIngestBudgetsV2 struct {
+	Data []GetIngestBudgetV2 `json:"data"`
+}

--- a/api/ingest-budgets-v2.go
+++ b/api/ingest-budgets-v2.go
@@ -1,5 +1,16 @@
 package api
 
+type CreateIngestBudgetV2Request struct {
+	Name           string `json:"name"`
+	Scope          string `json:"scope"`
+	CapacityBytes  int    `json:"capacityBytes"`
+	Timezone       string `json:"timezone"`
+	ResetTime      string `json:"resetTime"`
+	Description    string `json:"description"`
+	Action         string `json:"action"`
+	AuditThreshold int    `json:"auditThreshold"`
+}
+
 type GetIngestBudgetV2 struct {
 	Name           string `json:"name"`
 	Scope          string `json:"scope"`

--- a/api/ingest-budgets.go
+++ b/api/ingest-budgets.go
@@ -11,11 +11,15 @@ type CreateIngestBudgetRequest struct {
 	AuditThreshold int    `json:"auditThreshold"`
 }
 
+type GetAssociatedCollectors struct {
+	Data []associatedCollectorsDetail `json:"data"`
+}
+
 type GetIngestBudget struct {
 	Name               string               `json:"name"`
 	FieldValue         string               `json:"fieldValue"`
 	CapacityBytes      int                  `json:"capacityBytes"`
-	TimeZone           string               `json:"timeZone"`
+	TimeZone           string               `json:"timezone"`
 	ResetTime          string               `json:"resetTime"`
 	Description        string               `json:"description"`
 	Action             string               `json:"action"`
@@ -32,6 +36,11 @@ type GetIngestBudget struct {
 
 type ListIngestBudgets struct {
 	Data []GetIngestBudget `json:"data"`
+}
+
+type associatedCollectorsDetail struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type ingestBudgetUserInfo struct {

--- a/api/ingest-budgets.go
+++ b/api/ingest-budgets.go
@@ -1,0 +1,42 @@
+package api
+
+type CreateIngestBudgetRequest struct {
+	Name           string `json:"name"`
+	FieldValue     string `json:"fieldValue"`
+	CapacityBytes  int    `json:"capacityBytes"`
+	Timezone       string `json:"timezone"`
+	ResetTime      int    `json:"resetTime"`
+	Description    string `json:"description"`
+	Action         string `json:"action"`
+	AuditThreshold int    `json:"auditThreshold"`
+}
+
+type GetIngestBudget struct {
+	Name               string               `json:"name"`
+	FieldValue         string               `json:"fieldValue"`
+	CapacityBytes      int                  `json:"capacityBytes"`
+	TimeZone           string               `json:"timeZone"`
+	ResetTime          int                  `json:"resetTime"`
+	Description        string               `json:"description"`
+	Action             string               `json:"action"`
+	AuditThreshold     int                  `json:"auditThreshold"`
+	CreatedAt          string               `json:"createdAt"`
+	CreatedByUser      ingestBudgetUserInfo `json:"createdByUser"`
+	ModifiedAt         string               `json:"modifiedAt"`
+	ModifiedByUser     ingestBudgetUserInfo `json:"modifiedByUser"`
+	Id                 string               `json:"id"`
+	UsageBytes         int                  `json:"usageBytes"`
+	UsageStatus        string               `json:"usageStatus"`
+	NumberOfCollectors int                  `json:"numberOfCollectors"`
+}
+
+type ListIngestBudgets struct {
+	Data []GetIngestBudget `json:"data"`
+}
+
+type ingestBudgetUserInfo struct {
+	Id        string `json:"id"`
+	Email     string `json:"email"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+}

--- a/api/ingest-budgets.go
+++ b/api/ingest-budgets.go
@@ -5,7 +5,7 @@ type CreateIngestBudgetRequest struct {
 	FieldValue     string `json:"fieldValue"`
 	CapacityBytes  int    `json:"capacityBytes"`
 	Timezone       string `json:"timezone"`
-	ResetTime      int    `json:"resetTime"`
+	ResetTime      string `json:"resetTime"`
 	Description    string `json:"description"`
 	Action         string `json:"action"`
 	AuditThreshold int    `json:"auditThreshold"`
@@ -16,7 +16,7 @@ type GetIngestBudget struct {
 	FieldValue         string               `json:"fieldValue"`
 	CapacityBytes      int                  `json:"capacityBytes"`
 	TimeZone           string               `json:"timeZone"`
-	ResetTime          int                  `json:"resetTime"`
+	ResetTime          string               `json:"resetTime"`
 	Description        string               `json:"description"`
 	Action             string               `json:"action"`
 	AuditThreshold     int                  `json:"auditThreshold"`

--- a/api/password-policy.go
+++ b/api/password-policy.go
@@ -1,0 +1,17 @@
+package api
+
+type GetPasswordPolicy struct {
+	MinLength                      int  `json:"minLength"`
+	MaxLength                      int  `json:"maxLength"`
+	MustContainLowercase           bool `json:"mustContainLowercase"`
+	MustContainUppercase           bool `json:"mustContainUppercase"`
+	MustContainDigits              bool `json:"mustContainDigits"`
+	MustContainSpecialChars        bool `json:"mustContainSpecialChars"`
+	MaxPasswordAgeInDays           int  `json:"maxPasswordAgeInDays"`
+	MinUniquePasswords             int  `json:"minUniquePasswords"`
+	AccountLockoutThreshold        int  `json:"accountLockoutThreshold"`
+	FailedLoginResetDurationInMins int  `json:"failedLoginResetDurationInMins"`
+	AccountLockoutDurationInMins   int  `json:"accountLockoutDurationInMins"`
+	RequireMfa                     bool `json:"requireMfa"`
+	RememberMfa                    bool `json:"rememberMfa"`
+}

--- a/api/saml.go
+++ b/api/saml.go
@@ -1,5 +1,25 @@
 package api
 
+type CreateSamlRequest struct {
+	SpInitiatedLoginPath         string                     `json:"spInitiatedLoginPath"`
+	ConfigurationName            string                     `json:"configurationName"`
+	Issuer                       string                     `json:"issuer"`
+	SpInitiatedLoginEnabled      bool                       `json:"spInitiatedLoginEnabled"`
+	AuthnRequestUrl              string                     `json:"authnRequestUrl"`
+	X509Cert1                    string                     `json:"x509cert1"`
+	X509Cert2                    string                     `json:"x509cert2"`
+	X509Cert3                    string                     `json:"x509cert3"`
+	OnDemandProvisioningEnabled  OnDemandProvisioningDetail `json:"onDemandProvisioningEnabled"`
+	RolesAttribute               string                     `json:"rolesAttribute"`
+	LogoutEnabled                bool                       `json:"logoutEnabled"`
+	LogoutUrl                    string                     `json:"logoutUrl"`
+	EmailAttribute               string                     `json:"emailAttribute"`
+	DebugMode                    bool                       `json:"debugMode"`
+	SignAuthnRequest             bool                       `json:"signAuthnRequest"`
+	DisableRequestedAuthnContext bool                       `json:"disableRequestedAuthnContext"`
+	IsRedirectBinding            bool                       `json:"isRedirectBinding"`
+}
+
 type GetSamlAllowListUsers struct {
 	UserId        string `json:"userId"`
 	FirstName     string `json:"firstName"`
@@ -19,7 +39,7 @@ type GetSaml struct {
 	X509Cert1                    string                     `json:"x509cert1"`
 	X509Cert2                    string                     `json:"x509cert2"`
 	X509Cert3                    string                     `json:"x509cert3"`
-	OnDemandProvisioningEnabled  onDemandProvisioningDetail `json:"onDemandProvisioningEnabled"`
+	OnDemandProvisioningEnabled  OnDemandProvisioningDetail `json:"onDemandProvisioningEnabled"`
 	RolesAttribute               string                     `json:"rolesAttribute"`
 	LogoutEnabled                bool                       `json:"logoutEnabled"`
 	LogoutUrl                    string                     `json:"logoutUrl"`
@@ -36,7 +56,7 @@ type GetSaml struct {
 	Id                           string                     `json:"id"`
 }
 
-type onDemandProvisioningDetail struct {
+type OnDemandProvisioningDetail struct {
 	FirstNameAttribute        string   `json:"firstNameAttribute"`
 	LastNameAttribute         string   `json:"lastNameAttribute"`
 	OnDemandProvisioningRoles []string `json:"onDemandProvisioningRoles"`

--- a/api/saml.go
+++ b/api/saml.go
@@ -1,5 +1,15 @@
 package api
 
+type GetSamlAllowListUsers struct {
+	UserId        string `json:"userId"`
+	FirstName     string `json:"firstName"`
+	LastName      string `json:"lastName"`
+	Email         string `json:"email"`
+	CanManageSaml bool   `json:"canManageSaml"`
+	IsActive      bool   `json:"isActive"`
+	LastLogin     string `json:"lastLogin"`
+}
+
 type GetSaml struct {
 	SpInitiatedLoginPath         string                     `json:"spInitiatedLoginPath"`
 	ConfigurationName            string                     `json:"configurationName"`
@@ -27,7 +37,7 @@ type GetSaml struct {
 }
 
 type onDemandProvisioningDetail struct {
-	FirstNameAttribute        string `json:"firstNameAttribute"`
-	LastNameAttribute         string `json:"lastNameAttribute"`
-	OnDemandProvisioningRoles string `json:"onDemandProvisioningRoles"`
+	FirstNameAttribute        string   `json:"firstNameAttribute"`
+	LastNameAttribute         string   `json:"lastNameAttribute"`
+	OnDemandProvisioningRoles []string `json:"onDemandProvisioningRoles"`
 }

--- a/api/saml.go
+++ b/api/saml.go
@@ -1,0 +1,33 @@
+package api
+
+type GetSaml struct {
+	SpInitiatedLoginPath         string                     `json:"spInitiatedLoginPath"`
+	ConfigurationName            string                     `json:"configurationName"`
+	Issuer                       string                     `json:"issuer"`
+	SpInitiatedLoginEnabled      bool                       `json:"spInitiatedLoginEnabled"`
+	AuthnRequestUrl              string                     `json:"authnRequestUrl"`
+	X509Cert1                    string                     `json:"x509cert1"`
+	X509Cert2                    string                     `json:"x509cert2"`
+	X509Cert3                    string                     `json:"x509cert3"`
+	OnDemandProvisioningEnabled  onDemandProvisioningDetail `json:"onDemandProvisioningEnabled"`
+	RolesAttribute               string                     `json:"rolesAttribute"`
+	LogoutEnabled                bool                       `json:"logoutEnabled"`
+	LogoutUrl                    string                     `json:"logoutUrl"`
+	EmailAttribute               string                     `json:"emailAttribute"`
+	DebugMode                    bool                       `json:"debugMode"`
+	SignAuthnRequest             bool                       `json:"signAuthnRequest"`
+	DisableRequestedAuthnContext bool                       `json:"disableRequestedAuthnContext"`
+	IsRedirectBinding            bool                       `json:"isRedirectBinding"`
+	Certificate                  string                     `json:"certificate"`
+	CreatedAt                    string                     `json:"createdAt"`
+	CreatedBy                    string                     `json:"createdBy"`
+	ModifiedAt                   string                     `json:"modifiedAt"`
+	ModifiedBy                   string                     `json:"modifiedBy"`
+	Id                           string                     `json:"id"`
+}
+
+type onDemandProvisioningDetail struct {
+	FirstNameAttribute        string `json:"firstNameAttribute"`
+	LastNameAttribute         string `json:"lastNameAttribute"`
+	OnDemandProvisioningRoles string `json:"onDemandProvisioningRoles"`
+}

--- a/api/sources.go
+++ b/api/sources.go
@@ -47,7 +47,27 @@ type SourcesResponse struct {
 	AutomaticDateParsing       bool              `json:"automaticDateParsing"`
 	MultilineProcessingEnabled bool              `json:"multilineProcessingEnabled"`
 	UseAutolineMatching        bool              `json:"useAutolineMatching"`
-	ContentType                string            `json:"contentType"`
+	ForceTimezone              bool              `json:"forceTimezome"`
+	Filters                    []sourceFilters   `json:"filters"`
+	CutoffTimestamp            int               `json:"cutoffTimestamp"`
+	Encoding                   string            `json:"encoding"`
+	Interval                   int               `json:"interval"`
+	Metrics                    []string          `json:"metrics"`
+	SourceType                 string            `json:"sourceType"`
+	Alive                      bool              `json:"alive"`
+	Url                        string            `json:"url,omitempty"`
+	Category                   string            `json:"category,omitempty"`
+	Fields                     map[string]string `json:"fields,omitempty"`
+	MessagePerRequest          bool              `json:"messagePerRequest"`
+}
+
+type UpdateSourcesResponse struct {
+	Id                         string            `json:"id"`
+	Name                       string            `json:"name"`
+	HostName                   string            `json:"hostName,omitempty"`
+	AutomaticDateParsing       bool              `json:"automaticDateParsing"`
+	MultilineProcessingEnabled bool              `json:"multilineProcessingEnabled"`
+	UseAutolineMatching        bool              `json:"useAutolineMatching"`
 	ForceTimezone              bool              `json:"forceTimezome"`
 	Filters                    []sourceFilters   `json:"filters"`
 	CutoffTimestamp            int               `json:"cutoffTimestamp"`

--- a/pkg/cmd/access-keys/access-keys.go
+++ b/pkg/cmd/access-keys/access-keys.go
@@ -12,7 +12,7 @@ import (
 func NewCmdAccessKeys() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "access-keys",
-		Short: "Managed access keys",
+		Short: "Manage access keys",
 		Long:  "Commands that allow you to manage access keys in your Sumo Logic tenant",
 	}
 	cmd.AddCommand(cmdAccessKeysCreate.NewCmdAccessKeysCreate())

--- a/pkg/cmd/account/account.go
+++ b/pkg/cmd/account/account.go
@@ -1,0 +1,26 @@
+package account
+
+import (
+	"github.com/spf13/cobra"
+	NewCmdAccountCreateSubdomain "github.com/wizedkyle/sumocli/pkg/cmd/account/create-subdomain"
+	NewCmdAccountDeleteSubdomain "github.com/wizedkyle/sumocli/pkg/cmd/account/delete-subdomain"
+	NewCmdAccountGetOwner "github.com/wizedkyle/sumocli/pkg/cmd/account/get-owner"
+	NewCmdAccountGetSubdomain "github.com/wizedkyle/sumocli/pkg/cmd/account/get-subdomain"
+	NewCmdAccountRecoverSubdomain "github.com/wizedkyle/sumocli/pkg/cmd/account/recover-subdomain"
+	NewCmdAccountUpdateSubdomain "github.com/wizedkyle/sumocli/pkg/cmd/account/update-subdomain"
+)
+
+func NewCmdAccount() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "account",
+		Short: "Manage account settings",
+		Long:  "Commands that allow you to manage your Sumo Logic account settings",
+	}
+	cmd.AddCommand(NewCmdAccountCreateSubdomain.NewCmdAccountCreateSubdomain())
+	cmd.AddCommand(NewCmdAccountDeleteSubdomain.NewCmdAccountDeleteSubdomain())
+	cmd.AddCommand(NewCmdAccountGetOwner.NewCmdAccountGetOwner())
+	cmd.AddCommand(NewCmdAccountGetSubdomain.NewCmdAccountGetSubdomain())
+	cmd.AddCommand(NewCmdAccountRecoverSubdomain.NewCmdAccountRecoverSubdomain())
+	cmd.AddCommand(NewCmdAccountUpdateSubdomain.NewCmdAccountUpdateSubdomain())
+	return cmd
+}

--- a/pkg/cmd/account/create-subdomain/create-subdomain.go
+++ b/pkg/cmd/account/create-subdomain/create-subdomain.go
@@ -1,0 +1,66 @@
+package create_subdomain
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdAccountCreateSubdomain() *cobra.Command {
+	var subdomain string
+
+	cmd := &cobra.Command{
+		Use:   "create-subdomain",
+		Short: "Create a subdomain. Only the Account Owner can create a subdomain.",
+		Run: func(cmd *cobra.Command, args []string) {
+			createSubdomain(subdomain)
+		},
+	}
+	cmd.Flags().StringVar(&subdomain, "subdomain", "", "Specify a subdomain (minimum 4 and maximum 63 characters)")
+	cmd.MarkFlagRequired("subdomain")
+	return cmd
+}
+
+func createSubdomain(subdomain string) {
+	var subdomainResponse api.GetSubdomain
+	log := logging.GetConsoleLogger()
+	requestBodySchema := api.UpdateSubdomainRequest{
+		Subdomain: subdomain,
+	}
+	requestBody, err := json.Marshal(requestBodySchema)
+	if err != nil {
+		log.Error().Err(err).Msg("error marshalling request body")
+	}
+	requestUrl := "v1/account/subdomain"
+	client, request := factory.NewHttpRequestWithBody("POST", requestUrl, requestBody)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &subdomainResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	subdomainResponseJson, err := json.MarshalIndent(subdomainResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(subdomainResponseJson))
+	}
+}

--- a/pkg/cmd/account/delete-subdomain/delete-subdomain.go
+++ b/pkg/cmd/account/delete-subdomain/delete-subdomain.go
@@ -1,0 +1,48 @@
+package delete_subdomain
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdAccountDeleteSubdomain() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete-subdomain",
+		Short: "Delete the configured subdomain.",
+		Run: func(cmd *cobra.Command, args []string) {
+			deleteSubdomain()
+		},
+	}
+	return cmd
+}
+
+func deleteSubdomain() {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/account/subdomain"
+	client, request := factory.NewHttpRequest("DELETE", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("Subdomain was deleted.")
+	}
+}

--- a/pkg/cmd/account/get-owner/get-owner.go
+++ b/pkg/cmd/account/get-owner/get-owner.go
@@ -1,0 +1,41 @@
+package get_owner
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	GetUser "github.com/wizedkyle/sumocli/pkg/cmd/users/get"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+	"strings"
+)
+
+func NewCmdAccountGetOwner() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-owner",
+		Short: "Returns the user identifier of the account owner.",
+		Run: func(cmd *cobra.Command, args []string) {
+			getOwner()
+		},
+	}
+	return cmd
+}
+
+func getOwner() {
+	var userId string
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/account/accountOwner"
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+	userId = string(responseBody)
+	userId = strings.Trim(userId, "\"")
+	GetUser.GetUser(userId)
+}

--- a/pkg/cmd/account/get-subdomain/get-subdomain.go
+++ b/pkg/cmd/account/get-subdomain/get-subdomain.go
@@ -1,4 +1,4 @@
-package list_all
+package get_subdomain
 
 import (
 	"encoding/json"
@@ -8,32 +8,24 @@ import (
 	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
 	"github.com/wizedkyle/sumocli/pkg/logging"
 	"io"
-	"net/url"
-	"strconv"
 )
 
-func NewCmdAccessKeysListAll() *cobra.Command {
-	var limit int
-
+func NewCmdAccountGetSubdomain() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list-all",
-		Short: "List all access keys in your account.",
+		Use:   "get-subdomain",
+		Short: "Get the configured subdomain.",
 		Run: func(cmd *cobra.Command, args []string) {
-			listAllAccessKeys(limit)
+			getSubdomain()
 		},
 	}
-	cmd.Flags().IntVar(&limit, "limit", 100, "Specify the number of access keys returned")
 	return cmd
 }
 
-func listAllAccessKeys(limit int) {
-	var accessKeyResponse api.ListAccessKeysResponse
+func getSubdomain() {
+	var subdomainResponse api.GetSubdomain
 	log := logging.GetConsoleLogger()
-	requestUrl := "v1/accessKeys"
+	requestUrl := "v1/account/subdomain"
 	client, request := factory.NewHttpRequest("GET", requestUrl)
-	query := url.Values{}
-	query.Add("limit", strconv.Itoa(limit))
-	request.URL.RawQuery = query.Encode()
 	response, err := client.Do(request)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
@@ -45,12 +37,12 @@ func listAllAccessKeys(limit int) {
 		log.Error().Err(err).Msg("failed to read response body")
 	}
 
-	err = json.Unmarshal(responseBody, &accessKeyResponse)
+	err = json.Unmarshal(responseBody, &subdomainResponse)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal response body")
 	}
 
-	accessKeyResponseJson, err := json.MarshalIndent(accessKeyResponse, "", "    ")
+	subdomainResponseJson, err := json.MarshalIndent(subdomainResponse, "", "    ")
 	if err != nil {
 		log.Error().Err(err).Msg("failed to marshal response")
 	}
@@ -58,6 +50,6 @@ func listAllAccessKeys(limit int) {
 	if response.StatusCode != 200 {
 		factory.HttpError(response.StatusCode, responseBody, log)
 	} else {
-		fmt.Println(string(accessKeyResponseJson))
+		fmt.Println(string(subdomainResponseJson))
 	}
 }

--- a/pkg/cmd/account/recover-subdomain/recover-subdomain.go
+++ b/pkg/cmd/account/recover-subdomain/recover-subdomain.go
@@ -1,0 +1,56 @@
+package recover_subdomain
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+	"net/url"
+)
+
+func NewCmdAccountRecoverSubdomain() *cobra.Command {
+	var email string
+
+	cmd := &cobra.Command{
+		Use:   "recover-subdomain",
+		Short: "Send an email with the subdomain information for a user with the given email address.",
+		Run: func(cmd *cobra.Command, args []string) {
+			recoverSubdomain(email)
+		},
+	}
+	cmd.Flags().StringVar(&email, "email", "", "Specify an email address of the user to get subdomain information")
+	cmd.MarkFlagRequired("email")
+	return cmd
+}
+
+func recoverSubdomain(email string) {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/account/subdomain/recover"
+	client, request := factory.NewHttpRequest("POST", requestUrl)
+	query := url.Values{}
+	query.Add("email", email)
+	request.URL.RawQuery = query.Encode()
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("An email containing information about associated subdomains for the given email was sent.")
+	}
+}

--- a/pkg/cmd/account/update-subdomain/update-subdomain.go
+++ b/pkg/cmd/account/update-subdomain/update-subdomain.go
@@ -1,0 +1,66 @@
+package update_subdomain
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdAccountUpdateSubdomain() *cobra.Command {
+	var subdomain string
+
+	cmd := &cobra.Command{
+		Use:   "update-subdomain",
+		Short: "Update a subdomain. Only the Account Owner can update the subdomain.",
+		Run: func(cmd *cobra.Command, args []string) {
+			updateSubdomain(subdomain)
+		},
+	}
+	cmd.Flags().StringVar(&subdomain, "subdomain", "", "Specify a new subdomain (minimum 4 and maximum 63 characters)")
+	cmd.MarkFlagRequired("subdomain")
+	return cmd
+}
+
+func updateSubdomain(subdomain string) {
+	var subdomainResponse api.GetSubdomain
+	log := logging.GetConsoleLogger()
+	requestBodySchema := api.UpdateSubdomainRequest{
+		Subdomain: subdomain,
+	}
+	requestBody, err := json.Marshal(requestBodySchema)
+	if err != nil {
+		log.Error().Err(err).Msg("error marshalling request body")
+	}
+	requestUrl := "v1/account/subdomain"
+	client, request := factory.NewHttpRequestWithBody("PUT", requestUrl, requestBody)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &subdomainResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	subdomainResponseJson, err := json.MarshalIndent(subdomainResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(subdomainResponseJson))
+	}
+}

--- a/pkg/cmd/collectors/delete/delete.go
+++ b/pkg/cmd/collectors/delete/delete.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"fmt"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
@@ -90,9 +91,9 @@ func deleteCollector(aliveBeforeDays int, force bool, id string, offline bool) {
 		}
 		defer response.Body.Close()
 		if response.StatusCode == 200 {
-			log.Info().Msg("collector with id " + id + " has been deleted")
+			fmt.Println("collector with id " + id + " has been deleted")
 		} else {
-			log.Error().Msg("collector with id " + id + " failed to delete, please try again.")
+			fmt.Println("collector with id " + id + " failed to delete, please try again.")
 		}
 	}
 }

--- a/pkg/cmd/collectors/update/update.go
+++ b/pkg/cmd/collectors/update/update.go
@@ -179,7 +179,6 @@ func updateCollector(category string, collectorId int, cutoffTimestamp int, desc
 	}
 	err = json.Unmarshal(responseBody, &collectorInfo)
 	if err != nil {
-		fmt.Println(string(responseBody))
 		log.Error().Err(err).Msg("error unmarshalling response body")
 	}
 	collectorInfoJson, err := json.MarshalIndent(&collectorInfo, "", "    ")

--- a/pkg/cmd/ingest-budgets-v2/create/create.go
+++ b/pkg/cmd/ingest-budgets-v2/create/create.go
@@ -1,0 +1,96 @@
+package create
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdIngestBudgetsV2Create() *cobra.Command {
+	var (
+		action         string
+		auditThreshold int
+		capacityBytes  int
+		description    string
+		scope          string
+		name           string
+		resetTime      string
+		timezone       string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new ingest budget.",
+		Run: func(cmd *cobra.Command, args []string) {
+			createIngestBudgetV2(action, auditThreshold, capacityBytes, description, name, resetTime, scope, timezone)
+		},
+	}
+	cmd.Flags().StringVar(&action, "action", "", "Specify an action to take when ingest budget's capacity is reached."+
+		"Supported values are either stopCollecting or keepCollecting.")
+	cmd.Flags().IntVar(&auditThreshold, "auditThreshold", 1, "Specify a percentage of when an ingest budget's capacity usage is logged in the Audit Index")
+	cmd.Flags().IntVar(&capacityBytes, "capacityBytes", 0, "Specify the capacity of the ingest budget in bytes.")
+	cmd.Flags().StringVar(&description, "description", "", "Specify a description for the ingest budget")
+	cmd.Flags().StringVar(&name, "name", "", "Specify a name for the ingest budget")
+	cmd.Flags().StringVar(&resetTime, "resetTime", "", "Specify the reset time of the ingest bidget in HH:MM format")
+	cmd.Flags().StringVar(&scope, "scope", "", "Specify a scope which will be used to identify the messages on which the budget needs to be applied")
+	cmd.Flags().StringVar(&timezone, "timezone", "", "Specify the timezone of the reset time in IANA Time Zone format")
+	cmd.MarkFlagRequired("action")
+	cmd.MarkFlagRequired("capacityBytes")
+	cmd.MarkFlagRequired("name")
+	cmd.MarkFlagRequired("resetTime")
+	cmd.MarkFlagRequired("scope")
+	cmd.MarkFlagRequired("timezone")
+	return cmd
+}
+
+func createIngestBudgetV2(action string, auditThreshold int, capacityBytes int, description string, name string,
+	resetTime string, scope string, timezone string) {
+	var ingestBudgetResponse api.GetIngestBudgetV2
+	log := logging.GetConsoleLogger()
+	requestBodySchema := api.CreateIngestBudgetV2Request{
+		Name:           name,
+		Scope:          scope,
+		CapacityBytes:  capacityBytes,
+		Timezone:       timezone,
+		ResetTime:      resetTime,
+		Description:    description,
+		Action:         action,
+		AuditThreshold: auditThreshold,
+	}
+	requestBody, err := json.Marshal(requestBodySchema)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal request body")
+	}
+	requestUrl := "v2/ingestBudgets"
+	client, request := factory.NewHttpRequestWithBody("POST", requestUrl, requestBody)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal lookupTableResponse")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(ingestBudgetResponseJson))
+	}
+}

--- a/pkg/cmd/ingest-budgets-v2/delete/delete.go
+++ b/pkg/cmd/ingest-budgets-v2/delete/delete.go
@@ -1,0 +1,52 @@
+package delete
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdIngestBudgetsV2Delete() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete an ingest budget with the given identifier.",
+		Run: func(cmd *cobra.Command, args []string) {
+			deleteIngestBudgetV2(id)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func deleteIngestBudgetV2(id string) {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v2/ingestBudgets/" + id
+	client, request := factory.NewHttpRequest("DELETE", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("The ingest budget was deleted successfully.")
+	}
+}

--- a/pkg/cmd/ingest-budgets-v2/get/get.go
+++ b/pkg/cmd/ingest-budgets-v2/get/get.go
@@ -1,0 +1,1 @@
+package get

--- a/pkg/cmd/ingest-budgets-v2/get/get.go
+++ b/pkg/cmd/ingest-budgets-v2/get/get.go
@@ -1,1 +1,59 @@
 package get
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdIngestBudgetsV2Get() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get an ingest budget by the given identifier.",
+		Run: func(cmd *cobra.Command, args []string) {
+			getIngestBudgetV2(id)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func getIngestBudgetV2(id string) {
+	var ingestBudgetResponse api.GetIngestBudgetV2
+	log := logging.GetConsoleLogger()
+	requestUrl := "v2/ingestBudgets/" + id
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(ingestBudgetResponseJson))
+	}
+}

--- a/pkg/cmd/ingest-budgets-v2/ingest-budgets-v2.go
+++ b/pkg/cmd/ingest-budgets-v2/ingest-budgets-v2.go
@@ -2,7 +2,12 @@ package ingest_budgets_v2
 
 import (
 	"github.com/spf13/cobra"
+	NewCmdIngestBudgetsV2Create "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets-v2/create"
+	NewCmdIngestBudgetsV2Delete "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets-v2/delete"
+	NewCmdIngestBudgetsV2Get "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets-v2/get"
 	NewCmdIngestBudgetsV2List "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets-v2/list"
+	NewCmdIngestBudgetsV2Reset "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets-v2/reset"
+	NewCmdIngestBudgetsV2Update "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets-v2/update"
 )
 
 func NewCmdIngestBudgetsV2() *cobra.Command {
@@ -11,6 +16,11 @@ func NewCmdIngestBudgetsV2() *cobra.Command {
 		Short: "Manage ingest budgets (v2)",
 		Long:  "Ingest Budgets V2 provide you the ability to create and assign budgets to your log data by Fields instead of using a Field Value.",
 	}
+	cmd.AddCommand(NewCmdIngestBudgetsV2Create.NewCmdIngestBudgetsV2Create())
+	cmd.AddCommand(NewCmdIngestBudgetsV2Delete.NewCmdIngestBudgetsV2Delete())
+	cmd.AddCommand(NewCmdIngestBudgetsV2Get.NewCmdIngestBudgetsV2Get())
 	cmd.AddCommand(NewCmdIngestBudgetsV2List.NewCmdIngestBudgetsV2List())
+	cmd.AddCommand(NewCmdIngestBudgetsV2Reset.NewCmdIngestBudgetsV2Reset())
+	cmd.AddCommand(NewCmdIngestBudgetsV2Update.NewCmdIngestBudgetsV2Update())
 	return cmd
 }

--- a/pkg/cmd/ingest-budgets-v2/ingest-budgets-v2.go
+++ b/pkg/cmd/ingest-budgets-v2/ingest-budgets-v2.go
@@ -1,0 +1,1 @@
+package ingest_budgets_v2

--- a/pkg/cmd/ingest-budgets-v2/ingest-budgets-v2.go
+++ b/pkg/cmd/ingest-budgets-v2/ingest-budgets-v2.go
@@ -1,1 +1,16 @@
 package ingest_budgets_v2
+
+import (
+	"github.com/spf13/cobra"
+	NewCmdIngestBudgetsV2List "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets-v2/list"
+)
+
+func NewCmdIngestBudgetsV2() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ingest-budgets-v2",
+		Short: "Manage ingest budgets (v2)",
+		Long:  "Ingest Budgets V2 provide you the ability to create and assign budgets to your log data by Fields instead of using a Field Value.",
+	}
+	cmd.AddCommand(NewCmdIngestBudgetsV2List.NewCmdIngestBudgetsV2List())
+	return cmd
+}

--- a/pkg/cmd/ingest-budgets-v2/list/list.go
+++ b/pkg/cmd/ingest-budgets-v2/list/list.go
@@ -1,0 +1,63 @@
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+	"net/url"
+	"strconv"
+)
+
+func NewCmdIngestBudgetsV2List() *cobra.Command {
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Get a list of all ingest budgets.",
+		Run: func(cmd *cobra.Command, args []string) {
+			listIngestBudgetsV2(limit)
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 100, "Specify the number of results to return maximum is 1000")
+	return cmd
+}
+
+func listIngestBudgetsV2(limit int) {
+	var ingestBudgetResponse api.ListIngestBudgetsV2
+	log := logging.GetConsoleLogger()
+	requestUrl := "v2/ingestBudgets"
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	query := url.Values{}
+	query.Add("limit", strconv.Itoa(limit))
+	request.URL.RawQuery = query.Encode()
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(ingestBudgetResponseJson))
+	}
+}

--- a/pkg/cmd/ingest-budgets-v2/reset/reset.go
+++ b/pkg/cmd/ingest-budgets-v2/reset/reset.go
@@ -1,0 +1,52 @@
+package reset
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdIngestBudgetsV2Reset() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset ingest budget's current usage to 0 before the scheduled reset time.",
+		Run: func(cmd *cobra.Command, args []string) {
+			resetIngestBudgetV2(id)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func resetIngestBudgetV2(id string) {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v2/ingestBudgets/" + id + "/usage/reset"
+	client, request := factory.NewHttpRequest("POST", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("Ingest budget's usage was reset successfully.")
+	}
+}

--- a/pkg/cmd/ingest-budgets/assign-collector/assign-collector.go
+++ b/pkg/cmd/ingest-budgets/assign-collector/assign-collector.go
@@ -1,0 +1,64 @@
+package assign_collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdIngestBudgetsAssignCollector() *cobra.Command {
+	var (
+		collectorId string
+		id          string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "assign-collector",
+		Short: "Assign a Collector to a budget.",
+		Run: func(cmd *cobra.Command, args []string) {
+			assignCollector(collectorId, id)
+		},
+	}
+	cmd.Flags().StringVar(&collectorId, "collectorId", "", "Specify the collector id to add to the ingest budget")
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.MarkFlagRequired("collectorId")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func assignCollector(collectorId string, id string) {
+	var ingestBudgetResponse api.GetIngestBudget
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/ingestBudgets/" + id + "/collectors/" + collectorId
+	client, request := factory.NewHttpRequest("PUT", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(ingestBudgetResponseJson))
+	}
+}

--- a/pkg/cmd/ingest-budgets/create/create.go
+++ b/pkg/cmd/ingest-budgets/create/create.go
@@ -1,0 +1,54 @@
+package create
+
+import (
+	"encoding/json"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+)
+
+func NewCmdIngestBudgetsCreate() *cobra.Command {
+	var (
+		action         string
+		auditThreshold int
+		capacityBytes  int
+		description    string
+		fieldValue     string
+		name           string
+		resetTime      int
+		timezone       string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new ingest budget.",
+		Run: func(cmd *cobra.Command, args []string) {
+
+		},
+	}
+
+	return cmd
+}
+
+func createIngestBudget(action string, auditThreshold int, capacityBytes int, description string,
+	fieldValue string, name string, resetTime int, timezone string) {
+	var ingestBudgetResponse api.GetIngestBudget
+	log := logging.GetConsoleLogger()
+	requestBodySchema := api.CreateIngestBudgetRequest{
+		Name:           name,
+		FieldValue:     fieldValue,
+		CapacityBytes:  capacityBytes,
+		Timezone:       timezone,
+		ResetTime:      resetTime,
+		Description:    description,
+		Action:         action,
+		AuditThreshold: auditThreshold,
+	}
+	requestBody, err := json.Marshal(requestBodySchema)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal request body")
+	}
+	requestUrl := "v1/ingestBudgets"
+	client, request := factory.NewHttpRequestWithBody("GET", requestUrl, requestBody)
+}

--- a/pkg/cmd/ingest-budgets/create/create.go
+++ b/pkg/cmd/ingest-budgets/create/create.go
@@ -2,10 +2,12 @@ package create
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/wizedkyle/sumocli/api"
 	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
 	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
 )
 
 func NewCmdIngestBudgetsCreate() *cobra.Command {
@@ -16,7 +18,7 @@ func NewCmdIngestBudgetsCreate() *cobra.Command {
 		description    string
 		fieldValue     string
 		name           string
-		resetTime      int
+		resetTime      string
 		timezone       string
 	)
 
@@ -24,15 +26,29 @@ func NewCmdIngestBudgetsCreate() *cobra.Command {
 		Use:   "create",
 		Short: "Create a new ingest budget.",
 		Run: func(cmd *cobra.Command, args []string) {
-
+			createIngestBudget(action, auditThreshold, capacityBytes, description, fieldValue, name, resetTime, timezone)
 		},
 	}
-
+	cmd.Flags().StringVar(&action, "action", "", "Specify an action to take when ingest budget's capacity is reached."+
+		"Supported values are either stopCollecting or keepCollecting.")
+	cmd.Flags().IntVar(&auditThreshold, "auditThreshold", 1, "Specify a percentage of when an ingest budget's capacity usage is logged in the Audit Index")
+	cmd.Flags().IntVar(&capacityBytes, "capacityBytes", 0, "Specify the capacity of the ingest budget in bytes.")
+	cmd.Flags().StringVar(&description, "description", "", "Specify a description for the ingest budget")
+	cmd.Flags().StringVar(&fieldValue, "fieldValue", "", "Specify the custom field value that is used to assign Collectors to the ingest budget")
+	cmd.Flags().StringVar(&name, "name", "", "Specify a name for the ingest budget")
+	cmd.Flags().StringVar(&resetTime, "resetTime", "", "Specify the reset time of the ingest bidget in HH:MM format")
+	cmd.Flags().StringVar(&timezone, "timezone", "", "Specify the timezone of the reset time in IANA Time Zone format")
+	cmd.MarkFlagRequired("action")
+	cmd.MarkFlagRequired("capacityBytes")
+	cmd.MarkFlagRequired("fieldValue")
+	cmd.MarkFlagRequired("name")
+	cmd.MarkFlagRequired("resetTime")
+	cmd.MarkFlagRequired("timezone")
 	return cmd
 }
 
 func createIngestBudget(action string, auditThreshold int, capacityBytes int, description string,
-	fieldValue string, name string, resetTime int, timezone string) {
+	fieldValue string, name string, resetTime string, timezone string) {
 	var ingestBudgetResponse api.GetIngestBudget
 	log := logging.GetConsoleLogger()
 	requestBodySchema := api.CreateIngestBudgetRequest{
@@ -50,5 +66,31 @@ func createIngestBudget(action string, auditThreshold int, capacityBytes int, de
 		log.Error().Err(err).Msg("failed to marshal request body")
 	}
 	requestUrl := "v1/ingestBudgets"
-	client, request := factory.NewHttpRequestWithBody("GET", requestUrl, requestBody)
+	client, request := factory.NewHttpRequestWithBody("POST", requestUrl, requestBody)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal lookupTableResponse")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(ingestBudgetResponseJson))
+	}
 }

--- a/pkg/cmd/ingest-budgets/delete/delete.go
+++ b/pkg/cmd/ingest-budgets/delete/delete.go
@@ -1,0 +1,52 @@
+package delete
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdIngestBudgetsDelete() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete an ingest budget with the given identifier.",
+		Run: func(cmd *cobra.Command, args []string) {
+			deleteIngestBudget(id)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func deleteIngestBudget(id string) {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/ingestBudgets/" + id
+	client, request := factory.NewHttpRequest("DELETE", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("The ingest budget was deleted successfully.")
+	}
+}

--- a/pkg/cmd/ingest-budgets/get-associated-collectors/get-associated-collectors.go
+++ b/pkg/cmd/ingest-budgets/get-associated-collectors/get-associated-collectors.go
@@ -1,0 +1,68 @@
+package get_associated_collectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+	"net/url"
+	"strconv"
+)
+
+func NewCmdIngestBudgetsGetAssociatedCollectors() *cobra.Command {
+	var (
+		id    string
+		limit int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get-associated-collectors",
+		Short: "Get a list of Collectors assigned to an ingest budget.",
+		Run: func(cmd *cobra.Command, args []string) {
+			getAssociatedCollectors(id, limit)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.Flags().IntVar(&limit, "limit", 100, "Specify the number of results to return maximum is 1000")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func getAssociatedCollectors(id string, limit int) {
+	var associatedCollectorsResponse api.GetAssociatedCollectors
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/ingestBudgets/" + id + "/collectors"
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	query := url.Values{}
+	query.Add("limit", strconv.Itoa(limit))
+	request.URL.RawQuery = query.Encode()
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &associatedCollectorsResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	associatedCollectorResponseJson, err := json.MarshalIndent(associatedCollectorsResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(associatedCollectorResponseJson))
+	}
+}

--- a/pkg/cmd/ingest-budgets/get/get.go
+++ b/pkg/cmd/ingest-budgets/get/get.go
@@ -1,0 +1,59 @@
+package get
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdIngestBudgetsGet() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get an ingest budget by the given identifier.",
+		Run: func(cmd *cobra.Command, args []string) {
+			getIngestBudget(id)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func getIngestBudget(id string) {
+	var ingestBudgetResponse api.GetIngestBudget
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/ingestBudgets/" + id
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(ingestBudgetResponseJson))
+	}
+}

--- a/pkg/cmd/ingest-budgets/ingest-budgets.go
+++ b/pkg/cmd/ingest-budgets/ingest-budgets.go
@@ -2,11 +2,15 @@ package ingest_budgets
 
 import (
 	"github.com/spf13/cobra"
+	NewCmdIngestBudgetsAssignCollector "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/assign-collector"
 	NewCmdIngestBudgetsCreate "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/create"
 	NewCmdIngestBudgetsDelete "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/delete"
 	NewCmdIngestBudgetsGet "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/get"
+	NewCmdIngestBudgetsGetAssociatedCollectors "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/get-associated-collectors"
 	NewCmdIngestBudgetsList "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/list"
+	NewCmdIngestBudgetsRemoveCollector "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/remove-collector"
 	NewCmdIngestBudgetsReset "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/reset"
+	NewCmdIngestBudgetsUpdate "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/update"
 )
 
 func NewCmdIngestBudgets() *cobra.Command {
@@ -16,10 +20,14 @@ func NewCmdIngestBudgets() *cobra.Command {
 		Long: "Commands that allow you to manage ingest budgets (v1)." +
 			"Ingest Budgets allow you to control the capacity of daily ingestion volume sent to Sumo Logic from Collectors.",
 	}
+	cmd.AddCommand(NewCmdIngestBudgetsAssignCollector.NewCmdIngestBudgetsAssignCollector())
 	cmd.AddCommand(NewCmdIngestBudgetsCreate.NewCmdIngestBudgetsCreate())
 	cmd.AddCommand(NewCmdIngestBudgetsDelete.NewCmdIngestBudgetsDelete())
 	cmd.AddCommand(NewCmdIngestBudgetsGet.NewCmdIngestBudgetsGet())
+	cmd.AddCommand(NewCmdIngestBudgetsGetAssociatedCollectors.NewCmdIngestBudgetsGetAssociatedCollectors())
 	cmd.AddCommand(NewCmdIngestBudgetsList.NewCmdIngestBudgetsList())
+	cmd.AddCommand(NewCmdIngestBudgetsRemoveCollector.NewCmIngestBudgetsRemoveAssociatedCollector())
 	cmd.AddCommand(NewCmdIngestBudgetsReset.NewCmdIngestBudgetsReset())
+	cmd.AddCommand(NewCmdIngestBudgetsUpdate.NewCmdIngestBudgetsUpdate())
 	return cmd
 }

--- a/pkg/cmd/ingest-budgets/ingest-budgets.go
+++ b/pkg/cmd/ingest-budgets/ingest-budgets.go
@@ -1,0 +1,19 @@
+package ingest_budgets
+
+import (
+	"github.com/spf13/cobra"
+	NewCmdIngestBudgetsGet "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/get"
+	NewCmdIngestBudgetsList "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/list"
+)
+
+func NewCmdIngestBudgets() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ingest-budgets",
+		Short: "Manage ingest budgets (v1)",
+		Long: "Commands that allow you to manage ingest budgets (v1)." +
+			"Ingest Budgets allow you to control the capacity of daily ingestion volume sent to Sumo Logic from Collectors.",
+	}
+	cmd.AddCommand(NewCmdIngestBudgetsGet.NewCmdIngestBudgetsGet())
+	cmd.AddCommand(NewCmdIngestBudgetsList.NewCmdIngestBudgetsList())
+	return cmd
+}

--- a/pkg/cmd/ingest-budgets/ingest-budgets.go
+++ b/pkg/cmd/ingest-budgets/ingest-budgets.go
@@ -2,8 +2,11 @@ package ingest_budgets
 
 import (
 	"github.com/spf13/cobra"
+	NewCmdIngestBudgetsCreate "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/create"
+	NewCmdIngestBudgetsDelete "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/delete"
 	NewCmdIngestBudgetsGet "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/get"
 	NewCmdIngestBudgetsList "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/list"
+	NewCmdIngestBudgetsReset "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets/reset"
 )
 
 func NewCmdIngestBudgets() *cobra.Command {
@@ -13,7 +16,10 @@ func NewCmdIngestBudgets() *cobra.Command {
 		Long: "Commands that allow you to manage ingest budgets (v1)." +
 			"Ingest Budgets allow you to control the capacity of daily ingestion volume sent to Sumo Logic from Collectors.",
 	}
+	cmd.AddCommand(NewCmdIngestBudgetsCreate.NewCmdIngestBudgetsCreate())
+	cmd.AddCommand(NewCmdIngestBudgetsDelete.NewCmdIngestBudgetsDelete())
 	cmd.AddCommand(NewCmdIngestBudgetsGet.NewCmdIngestBudgetsGet())
 	cmd.AddCommand(NewCmdIngestBudgetsList.NewCmdIngestBudgetsList())
+	cmd.AddCommand(NewCmdIngestBudgetsReset.NewCmdIngestBudgetsReset())
 	return cmd
 }

--- a/pkg/cmd/ingest-budgets/list/list.go
+++ b/pkg/cmd/ingest-budgets/list/list.go
@@ -1,0 +1,63 @@
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+	"net/url"
+	"strconv"
+)
+
+func NewCmdIngestBudgetsList() *cobra.Command {
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Get a list of all ingest budgets.",
+		Run: func(cmd *cobra.Command, args []string) {
+			listIngestBudgets(limit)
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 100, "Specify the number of results to return maximum is 1000")
+	return cmd
+}
+
+func listIngestBudgets(limit int) {
+	var ingestBudgetResponse api.ListIngestBudgets
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/ingestBudgets"
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	query := url.Values{}
+	query.Add("limit", strconv.Itoa(limit))
+	request.URL.RawQuery = query.Encode()
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(ingestBudgetResponseJson))
+	}
+}

--- a/pkg/cmd/ingest-budgets/remove-collector/remove-collector.go
+++ b/pkg/cmd/ingest-budgets/remove-collector/remove-collector.go
@@ -1,0 +1,64 @@
+package remove_collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmIngestBudgetsRemoveAssociatedCollector() *cobra.Command {
+	var (
+		collectorId string
+		id          string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "remove-collector",
+		Short: "Remove Collector from a budget.",
+		Run: func(cmd *cobra.Command, args []string) {
+			removeAssociatedCollector(collectorId, id)
+		},
+	}
+	cmd.Flags().StringVar(&collectorId, "collectorId", "", "Specify the collector id to remove from the ingest budget")
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.MarkFlagRequired("collectorId")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func removeAssociatedCollector(collectorId string, id string) {
+	var ingestBudgetResponse api.GetIngestBudget
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/ingestBudgets/" + id + "/collectors/" + collectorId
+	client, request := factory.NewHttpRequest("DELETE", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(ingestBudgetResponseJson))
+	}
+}

--- a/pkg/cmd/ingest-budgets/reset/reset.go
+++ b/pkg/cmd/ingest-budgets/reset/reset.go
@@ -1,0 +1,52 @@
+package reset
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdIngestBudgetsReset() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset ingest budget's current usage to 0 before the scheduled reset time.",
+		Run: func(cmd *cobra.Command, args []string) {
+			resetIngestBudget(id)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func resetIngestBudget(id string) {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/ingestBudgets/" + id + "/usage/reset"
+	client, request := factory.NewHttpRequest("POST", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("Ingest budget's usage was reset successfully.")
+	}
+}

--- a/pkg/cmd/ingest-budgets/update/update.go
+++ b/pkg/cmd/ingest-budgets/update/update.go
@@ -1,0 +1,22 @@
+package update
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCmdIngestBudgetsUpdate() *cobra.Command {
+	var ()
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "",
+		Run: func(cmd *cobra.Command, args []string) {
+
+		},
+	}
+	return cmd
+}
+
+func updateIngestBudget() {
+
+}

--- a/pkg/cmd/ingest-budgets/update/update.go
+++ b/pkg/cmd/ingest-budgets/update/update.go
@@ -1,22 +1,201 @@
 package update
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+	"strconv"
+	"strings"
 )
 
 func NewCmdIngestBudgetsUpdate() *cobra.Command {
-	var ()
+	var (
+		action         string
+		auditThreshold int
+		capacityBytes  int
+		description    string
+		fieldValue     string
+		id             string
+		merge          bool
+		name           string
+		resetTime      string
+		timezone       string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "",
+		Short: "Update an existing ingest budget.",
 		Run: func(cmd *cobra.Command, args []string) {
-
+			updateIngestBudget(action, auditThreshold, capacityBytes, description, fieldValue, id, merge,
+				name, resetTime, timezone)
 		},
 	}
+	cmd.Flags().StringVar(&action, "action", "", "Specify an action to take when ingest budget's capacity is reached."+
+		"Supported values are either stopCollecting or keepCollecting.")
+	cmd.Flags().IntVar(&auditThreshold, "auditThreshold", 1, "Specify a percentage of when an ingest budget's capacity usage is logged in the Audit Index")
+	cmd.Flags().IntVar(&capacityBytes, "capacityBytes", 0, "Specify the capacity of the ingest budget in bytes.")
+	cmd.Flags().StringVar(&description, "description", "", "Specify a description for the ingest budget")
+	cmd.Flags().StringVar(&fieldValue, "fieldValue", "", "Specify the custom field value that is used to assign Collectors to the ingest budget")
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the ingest budget")
+	cmd.Flags().BoolVar(&merge, "merge", true, "If set to false it will overwrite the ingest budget configuration")
+	cmd.Flags().StringVar(&name, "name", "", "Specify a name for the ingest budget")
+	cmd.Flags().StringVar(&resetTime, "resetTime", "", "Specify the reset time of the ingest bidget in HH:MM format")
+	cmd.Flags().StringVar(&timezone, "timezone", "", "Specify the timezone of the reset time in IANA Time Zone format")
+	cmd.MarkFlagRequired("action")
+	cmd.MarkFlagRequired("capacityBytes")
+	cmd.MarkFlagRequired("fieldValue")
+	cmd.MarkFlagRequired("id")
+	cmd.MarkFlagRequired("name")
+	cmd.MarkFlagRequired("resetTime")
+	cmd.MarkFlagRequired("timezone")
 	return cmd
 }
 
-func updateIngestBudget() {
+func updateIngestBudget(action string, auditThreshold int, capacityBytes int, description string, fieldValue string, id string, merge bool,
+	name string, resetTime string, timezone string) {
+	log := logging.GetConsoleLogger()
+	var ingestBudgetResponse api.GetIngestBudget
+	if merge == true {
+		requestUrl := "v1/ingestBudgets/" + id
+		client, request := factory.NewHttpRequest("GET", requestUrl)
+		response, err := client.Do(request)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to make http request " + requestUrl)
+		}
+		defer response.Body.Close()
+		responseBody, err := io.ReadAll(response.Body)
+		if err != nil {
+			log.Error().Err(err).Msg("error reading response body from request")
+		}
+		err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+		if response.StatusCode != 200 {
+			log.Fatal().Msg("Error code = " + strconv.Itoa(response.StatusCode) + string(responseBody))
+		}
 
+		// Building body payload to update the ingest budget based on the differences
+		// between the current ingest budget and the desired settings
+		requestBodySchema := &api.GetIngestBudget{}
+		if strings.EqualFold(ingestBudgetResponse.Action, action) {
+			requestBodySchema.Action = ingestBudgetResponse.Action
+		} else {
+			requestBodySchema.Action = action
+		}
+
+		if ingestBudgetResponse.AuditThreshold == auditThreshold {
+			requestBodySchema.AuditThreshold = ingestBudgetResponse.AuditThreshold
+		} else {
+			requestBodySchema.AuditThreshold = auditThreshold
+		}
+
+		if ingestBudgetResponse.CapacityBytes == capacityBytes {
+			requestBodySchema.CapacityBytes = ingestBudgetResponse.CapacityBytes
+		} else {
+			requestBodySchema.CapacityBytes = capacityBytes
+		}
+
+		if strings.EqualFold(ingestBudgetResponse.Description, description) {
+			requestBodySchema.Description = ingestBudgetResponse.Description
+		} else {
+			requestBodySchema.Description = description
+		}
+
+		if strings.EqualFold(ingestBudgetResponse.FieldValue, fieldValue) {
+			requestBodySchema.FieldValue = ingestBudgetResponse.FieldValue
+		} else {
+			requestBodySchema.FieldValue = fieldValue
+		}
+
+		if strings.EqualFold(ingestBudgetResponse.Name, name) {
+			requestBodySchema.Name = ingestBudgetResponse.Name
+		} else {
+			requestBodySchema.Name = name
+		}
+
+		if strings.EqualFold(ingestBudgetResponse.ResetTime, resetTime) {
+			requestBodySchema.ResetTime = ingestBudgetResponse.ResetTime
+		} else {
+			requestBodySchema.ResetTime = resetTime
+		}
+
+		if strings.EqualFold(ingestBudgetResponse.TimeZone, timezone) {
+			requestBodySchema.TimeZone = ingestBudgetResponse.TimeZone
+		} else {
+			requestBodySchema.TimeZone = timezone
+		}
+
+		requestBody, err := json.Marshal(requestBodySchema)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to marshal request body")
+		}
+		client, request = factory.NewHttpRequestWithBody("PUT", requestUrl, requestBody)
+		response, err = client.Do(request)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to make http request " + requestUrl)
+		}
+		defer response.Body.Close()
+		responseBody, err = io.ReadAll(response.Body)
+		if err != nil {
+			log.Error().Err(err).Msg("error reading response body from request")
+		}
+		err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+		ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+		if err != nil {
+			log.Error().Err(err).Msg("error marshalling response body")
+		}
+		if response.StatusCode != 200 {
+			factory.HttpError(response.StatusCode, responseBody, log)
+		} else {
+			fmt.Println(string(ingestBudgetResponseJson))
+		}
+	} else {
+		requestBodySchema := &api.CreateIngestBudgetRequest{
+			Name:           name,
+			FieldValue:     fieldValue,
+			CapacityBytes:  capacityBytes,
+			Timezone:       timezone,
+			ResetTime:      resetTime,
+			Description:    description,
+			Action:         action,
+			AuditThreshold: auditThreshold,
+		}
+		requestBody, err := json.Marshal(requestBodySchema)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to marshal request body")
+		}
+		requestUrl := "v1/ingestBudgets/" + id
+		client, request := factory.NewHttpRequestWithBody("PUT", requestUrl, requestBody)
+		response, err := client.Do(request)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to make http request")
+		}
+
+		defer response.Body.Close()
+		responseBody, err := io.ReadAll(response.Body)
+		if err != nil {
+			log.Error().Err(err).Msg("error reading response body from request")
+		}
+		err = json.Unmarshal(responseBody, &ingestBudgetResponse)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+		ingestBudgetResponseJson, err := json.MarshalIndent(ingestBudgetResponse, "", "    ")
+		if err != nil {
+			log.Error().Err(err).Msg("error marshalling response body")
+		}
+		if response.StatusCode != 200 {
+			factory.HttpError(response.StatusCode, responseBody, log)
+		} else {
+			fmt.Println(string(ingestBudgetResponseJson))
+		}
+	}
 }

--- a/pkg/cmd/password-policy/get/get.go
+++ b/pkg/cmd/password-policy/get/get.go
@@ -1,0 +1,55 @@
+package get
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdPasswordPolicyGet() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get the current password policy.",
+		Run: func(cmd *cobra.Command, args []string) {
+			getPasswordPolicy()
+		},
+	}
+	return cmd
+}
+
+func getPasswordPolicy() {
+	var passwordPolicyResponse api.GetPasswordPolicy
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/passwordPolicy"
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &passwordPolicyResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	passwordPolicyResponseJson, err := json.MarshalIndent(passwordPolicyResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(passwordPolicyResponseJson))
+	}
+}

--- a/pkg/cmd/password-policy/password-policy.go
+++ b/pkg/cmd/password-policy/password-policy.go
@@ -1,0 +1,18 @@
+package password_policy
+
+import (
+	"github.com/spf13/cobra"
+	NewCmdPasswordPolicyGet "github.com/wizedkyle/sumocli/pkg/cmd/password-policy/get"
+	NewCmdPasswordPolicyUpdate "github.com/wizedkyle/sumocli/pkg/cmd/password-policy/update"
+)
+
+func NewCmdPasswordPolicy() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "password-policy",
+		Short: "Manage password policy",
+		Long:  "Commands that allow you to modify the password policy in your Sumo Logic tenant",
+	}
+	cmd.AddCommand(NewCmdPasswordPolicyGet.NewCmdPasswordPolicyGet())
+	cmd.AddCommand(NewCmdPasswordPolicyUpdate.NewCmdPasswordPolicyUpdate())
+	return cmd
+}

--- a/pkg/cmd/password-policy/update/update.go
+++ b/pkg/cmd/password-policy/update/update.go
@@ -1,0 +1,108 @@
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdPasswordPolicyUpdate() *cobra.Command {
+	var (
+		minLength                      int
+		maxLength                      int
+		mustContainLowercase           bool
+		mustContainUppercase           bool
+		mustContainDigits              bool
+		mustContainSpecialCharacters   bool
+		maxPasswordAgeInDays           int
+		minUniquePasswords             int
+		accountLockoutThreshold        int
+		failedLoginResetDurationInMins int
+		accountLockoutDurationInMins   int
+		requireMfa                     bool
+		rememberMfa                    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update the current password policy.",
+		Run: func(cmd *cobra.Command, args []string) {
+			updatePasswordPolicy(minLength, maxLength, mustContainLowercase, mustContainUppercase, mustContainDigits,
+				mustContainSpecialCharacters, maxPasswordAgeInDays, minUniquePasswords, accountLockoutThreshold,
+				failedLoginResetDurationInMins, accountLockoutDurationInMins, requireMfa, rememberMfa)
+		},
+	}
+	cmd.Flags().IntVar(&minLength, "minLength", 8, "Specify the minimum password length")
+	cmd.Flags().IntVar(&maxLength, "maxLength", 128, "Specify the maximum password length")
+	cmd.Flags().BoolVar(&mustContainLowercase, "mustContainLowercase", true, "Set to false if you don't require passwords to contain lower case characters")
+	cmd.Flags().BoolVar(&mustContainUppercase, "mustContainUppercase", true, "Set to false if you don't require passwords to contain upper case characters")
+	cmd.Flags().BoolVar(&mustContainDigits, "mustContainDigits", true, "Set to false if you don't require passwords to contain digits")
+	cmd.Flags().BoolVar(&mustContainSpecialCharacters, "mustContainSpecialCharacters", true, "set to false if you don't require passwords to contain special characters")
+	cmd.Flags().IntVar(&maxPasswordAgeInDays, "maxPasswordAgeInDays", 365, "Specify the maximum password age (in days)")
+	cmd.Flags().IntVar(&minUniquePasswords, "minUniquePasswords", 10, "Specify the minimum number of unique new passwords that a user must use before an old password can be reused.")
+	cmd.Flags().IntVar(&accountLockoutThreshold, "accountLockoutThreshold", 6, "Specify the number of failed login attempts allowed before account is locked-out.")
+	cmd.Flags().IntVar(&failedLoginResetDurationInMins, "failedLoginResetDurationInMins", 10, "Specify the duration of time in minutes that must elapse from the first failed login attempt after which failed login count is reset to 0.")
+	cmd.Flags().IntVar(&accountLockoutDurationInMins, "accountLockoutDurationInMins", 30, "Specify the duration of time in minutes that a locked-out account remained locked before getting unlocked automatically.")
+	cmd.Flags().BoolVar(&requireMfa, "requireMfa", false, "Set to true if you require users to have MFA enabled")
+	cmd.Flags().BoolVar(&rememberMfa, "rememberMfa", true, "Set to false if MFA should not be remembered on the browser.")
+	return cmd
+}
+
+func updatePasswordPolicy(minLength int, maxLength int, mustContainLowercase bool, mustContainUppercase bool,
+	mustContainDigits bool, mustContainSpecialCharacters bool, maxPasswordAgeInDays int, minUniquePasswords int,
+	accountLockoutThreshold int, failedLoginResetDurationInMins int, accountLockoutDurationInMins int,
+	requireMfa bool, rememberMfa bool) {
+	var passwordPolicyResponse api.GetPasswordPolicy
+	log := logging.GetConsoleLogger()
+	requestBodySchema := api.GetPasswordPolicy{
+		MinLength:                      minLength,
+		MaxLength:                      maxLength,
+		MustContainLowercase:           mustContainLowercase,
+		MustContainUppercase:           mustContainUppercase,
+		MustContainDigits:              mustContainDigits,
+		MustContainSpecialChars:        mustContainSpecialCharacters,
+		MaxPasswordAgeInDays:           maxPasswordAgeInDays,
+		MinUniquePasswords:             minUniquePasswords,
+		AccountLockoutThreshold:        accountLockoutThreshold,
+		FailedLoginResetDurationInMins: failedLoginResetDurationInMins,
+		AccountLockoutDurationInMins:   accountLockoutDurationInMins,
+		RequireMfa:                     requireMfa,
+		RememberMfa:                    rememberMfa,
+	}
+	requestBody, err := json.Marshal(requestBodySchema)
+	if err != nil {
+		log.Error().Err(err).Msg("error marshalling request body")
+	}
+	requestUrl := "v1/passwordPolicy"
+	client, request := factory.NewHttpRequestWithBody("PUT", requestUrl, requestBody)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &passwordPolicyResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	passwordPolicyResponseJson, err := json.MarshalIndent(passwordPolicyResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(passwordPolicyResponseJson))
+	}
+}

--- a/pkg/cmd/roles/update/update.go
+++ b/pkg/cmd/roles/update/update.go
@@ -35,7 +35,6 @@ func NewCmdRoleUpdate() *cobra.Command {
 			logger.Debug().Msg("Role update request finished.")
 		},
 	}
-
 	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the role to update.")
 	cmd.Flags().StringVar(&name, "name", "", "Specify the name for the role.")
 	cmd.Flags().StringVar(&description, "description", "", "Specify the role description.")
@@ -43,7 +42,7 @@ func NewCmdRoleUpdate() *cobra.Command {
 	cmd.Flags().StringSliceVar(&users, "users", []string{}, "Comma deliminated list of user ids to add to the role.")
 	cmd.Flags().StringSliceVar(&capabilities, "capabilities", []string{}, "Comma deliminated list of capabilities.")
 	cmd.Flags().BoolVar(&autofill, "autofill", true, "Is set to true by default.")
-	cmd.Flags().BoolVar(&merge, "merge", true, "Is set to true by default, if set to false it will overwrite the role.")
+	cmd.Flags().BoolVar(&merge, "merge", true, "If set to false it will overwrite the role configuration")
 	cmd.MarkFlagRequired("id")
 	cmd.MarkFlagRequired("name")
 	cmd.MarkFlagRequired("description")

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -10,6 +10,7 @@ import (
 	contentCmd "github.com/wizedkyle/sumocli/pkg/cmd/content"
 	dashboardsCmd "github.com/wizedkyle/sumocli/pkg/cmd/dashboards"
 	foldersCmd "github.com/wizedkyle/sumocli/pkg/cmd/folders"
+	ingestBudgetsCmd "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets"
 	liveTailCmd "github.com/wizedkyle/sumocli/pkg/cmd/live-tail"
 	loginCmd "github.com/wizedkyle/sumocli/pkg/cmd/login"
 	lookupTablesCmd "github.com/wizedkyle/sumocli/pkg/cmd/lookup-tables"
@@ -42,6 +43,7 @@ func NewCmdRoot() *cobra.Command {
 	cmd.AddCommand(contentCmd.NewCmdContent())
 	cmd.AddCommand(dashboardsCmd.NewCmdDashboards())
 	cmd.AddCommand(foldersCmd.NewCmdFolders())
+	cmd.AddCommand(ingestBudgetsCmd.NewCmdIngestBudgets())
 	cmd.AddCommand(liveTailCmd.NewCmdLiveTail())
 	cmd.AddCommand(loginCmd.NewCmdLogin())
 	cmd.AddCommand(lookupTablesCmd.NewCmdLookupTables())

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -16,6 +16,7 @@ import (
 	passwordPolicyCmd "github.com/wizedkyle/sumocli/pkg/cmd/password-policy"
 	permissionsCmd "github.com/wizedkyle/sumocli/pkg/cmd/permissions"
 	roleCmd "github.com/wizedkyle/sumocli/pkg/cmd/roles"
+	samlCmd "github.com/wizedkyle/sumocli/pkg/cmd/saml"
 	serviceAllowlistCmd "github.com/wizedkyle/sumocli/pkg/cmd/service-allowlist"
 	sourcesCmd "github.com/wizedkyle/sumocli/pkg/cmd/sources"
 	tokensCmd "github.com/wizedkyle/sumocli/pkg/cmd/tokens"
@@ -47,6 +48,7 @@ func NewCmdRoot() *cobra.Command {
 	cmd.AddCommand(passwordPolicyCmd.NewCmdPasswordPolicy())
 	cmd.AddCommand(permissionsCmd.NewCmdPermissions())
 	cmd.AddCommand(roleCmd.NewCmdRole())
+	cmd.AddCommand(samlCmd.NewCmdSaml())
 	cmd.AddCommand(serviceAllowlistCmd.NewCmdServiceAllowlist())
 	cmd.AddCommand(sourcesCmd.NewCmdSources())
 	cmd.AddCommand(tokensCmd.NewCmdTokens())

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -11,6 +11,7 @@ import (
 	dashboardsCmd "github.com/wizedkyle/sumocli/pkg/cmd/dashboards"
 	foldersCmd "github.com/wizedkyle/sumocli/pkg/cmd/folders"
 	ingestBudgetsCmd "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets"
+	ingestBudgetsV2Cmd "github.com/wizedkyle/sumocli/pkg/cmd/ingest-budgets-v2"
 	liveTailCmd "github.com/wizedkyle/sumocli/pkg/cmd/live-tail"
 	loginCmd "github.com/wizedkyle/sumocli/pkg/cmd/login"
 	lookupTablesCmd "github.com/wizedkyle/sumocli/pkg/cmd/lookup-tables"
@@ -44,6 +45,7 @@ func NewCmdRoot() *cobra.Command {
 	cmd.AddCommand(dashboardsCmd.NewCmdDashboards())
 	cmd.AddCommand(foldersCmd.NewCmdFolders())
 	cmd.AddCommand(ingestBudgetsCmd.NewCmdIngestBudgets())
+	cmd.AddCommand(ingestBudgetsV2Cmd.NewCmdIngestBudgetsV2())
 	cmd.AddCommand(liveTailCmd.NewCmdLiveTail())
 	cmd.AddCommand(loginCmd.NewCmdLogin())
 	cmd.AddCommand(lookupTablesCmd.NewCmdLookupTables())

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -3,6 +3,7 @@ package root
 import (
 	"github.com/spf13/cobra"
 	accessKeysCmd "github.com/wizedkyle/sumocli/pkg/cmd/access-keys"
+	accountCmd "github.com/wizedkyle/sumocli/pkg/cmd/account"
 	appsCmd "github.com/wizedkyle/sumocli/pkg/cmd/apps"
 	azureCmd "github.com/wizedkyle/sumocli/pkg/cmd/azure"
 	collectorCmd "github.com/wizedkyle/sumocli/pkg/cmd/collectors"
@@ -31,6 +32,7 @@ func NewCmdRoot() *cobra.Command {
 	}
 
 	// Add subcommands
+	cmd.AddCommand(accountCmd.NewCmdAccount())
 	cmd.AddCommand(accessKeysCmd.NewCmdAccessKeys())
 	cmd.AddCommand(appsCmd.NewCmdApps())
 	cmd.AddCommand(azureCmd.NewCmdAzure())

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -13,6 +13,7 @@ import (
 	liveTailCmd "github.com/wizedkyle/sumocli/pkg/cmd/live-tail"
 	loginCmd "github.com/wizedkyle/sumocli/pkg/cmd/login"
 	lookupTablesCmd "github.com/wizedkyle/sumocli/pkg/cmd/lookup-tables"
+	passwordPolicyCmd "github.com/wizedkyle/sumocli/pkg/cmd/password-policy"
 	permissionsCmd "github.com/wizedkyle/sumocli/pkg/cmd/permissions"
 	roleCmd "github.com/wizedkyle/sumocli/pkg/cmd/roles"
 	serviceAllowlistCmd "github.com/wizedkyle/sumocli/pkg/cmd/service-allowlist"
@@ -43,6 +44,7 @@ func NewCmdRoot() *cobra.Command {
 	cmd.AddCommand(liveTailCmd.NewCmdLiveTail())
 	cmd.AddCommand(loginCmd.NewCmdLogin())
 	cmd.AddCommand(lookupTablesCmd.NewCmdLookupTables())
+	cmd.AddCommand(passwordPolicyCmd.NewCmdPasswordPolicy())
 	cmd.AddCommand(permissionsCmd.NewCmdPermissions())
 	cmd.AddCommand(roleCmd.NewCmdRole())
 	cmd.AddCommand(serviceAllowlistCmd.NewCmdServiceAllowlist())

--- a/pkg/cmd/saml/add-allowlist-user/add-allowlist-user.go
+++ b/pkg/cmd/saml/add-allowlist-user/add-allowlist-user.go
@@ -1,0 +1,59 @@
+package add_allowlist_user
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdSamlAddAllowListUser() *cobra.Command {
+	var userId string
+
+	cmd := &cobra.Command{
+		Use:   "add-allowlist-user",
+		Short: "Allowlist a user from SAML lockdown allowing them to sign in using a password in addition to SAML.",
+		Run: func(cmd *cobra.Command, args []string) {
+			addAllowListUser(userId)
+		},
+	}
+	cmd.Flags().StringVar(&userId, "userId", "", "Specify the id of the user")
+	cmd.MarkFlagRequired("userId")
+	return cmd
+}
+
+func addAllowListUser(userId string) {
+	var allowListResponse api.GetSamlAllowListUsers
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/saml/allowlistedUsers/" + userId
+	client, request := factory.NewHttpRequest("POST", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &allowListResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	allowListResponseJson, err := json.MarshalIndent(allowListResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(allowListResponseJson))
+	}
+}

--- a/pkg/cmd/saml/create-configuration/create-configuration.go
+++ b/pkg/cmd/saml/create-configuration/create-configuration.go
@@ -1,0 +1,1 @@
+package create_configuration

--- a/pkg/cmd/saml/create-configuration/create-configuration.go
+++ b/pkg/cmd/saml/create-configuration/create-configuration.go
@@ -1,1 +1,65 @@
 package create_configuration
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewCmdSamlCreateConfiguration() *cobra.Command {
+	var (
+		spInitiatedLoginPath       string
+		configurationName          string
+		issuer                     string
+		spInitiatedLoginEnabled    bool
+		authnRequestUrl            string
+		x509cert1                  string
+		x509cert2                  string
+		x509cert3                  string
+		firstNameAttribute         string
+		lastNameAttribute          string
+		onDemandProvisioningRoles  string
+		rolesAttribute             string
+		logoutEnabled              bool
+		logoutUrl                  string
+		emailAttribute             string
+		debugMode                  bool
+		signAuthnRequest           bool
+		disableRequestAuthnContext bool
+		isRedirectBinding          bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create-configuration",
+		Short: "Create a new SAML configuration in the organization.",
+		Run: func(cmd *cobra.Command, args []string) {
+
+		},
+	}
+	cmd.Flags().StringVar(&spInitiatedLoginPath, "spInitiatedLoginPath", "", "Specify the identifier used to generate a unique URL for user login")
+	cmd.Flags().StringVar(&configurationName, "configurationName", "", "Specify the name of the SSO policy or another name used to described the policy internally")
+	cmd.Flags().StringVar(&issuer, "issuer", "", "Specify the unique URL assigned to the organization by the SAML Identity Provider")
+	cmd.Flags().BoolVar(&spInitiatedLoginEnabled, "spInitiatedLoginEnabled", false, "Set to true if Sumo Logic redirects users to your identity provider with a SAML AuthnRequest when signing in")
+	cmd.Flags().StringVar(&authnRequestUrl, "authnRequestUrl", "", "Specify the URL that the identity provider has assigned for Sumo Logic to submit SAML authentication requests to the identity provider")
+	cmd.Flags().StringVar(&x509cert1, "x509cert1", "", "Specify the certificate that is used to verify the signature in SAML assertions")
+	cmd.Flags().StringVar(&x509cert2, "x509cert2", "", "Specify a backup certificate used to verify the signature in SAML assertions when x509cert1 expires (optional)")
+	cmd.Flags().StringVar(&x509cert3, "x509cert3", "", "Specify a backup certificate used to verify the signature in SAML assertions when x509cert1 expires and x509cert2 is empty (optional)")
+	cmd.Flags().StringVar(&firstNameAttribute, "firstNameAttribute", "", "Specify the first name attribute of the new user account")
+	cmd.Flags().StringVar(&lastNameAttribute, "lastNameAttribute", "", "Specify the last name attribute of the new user account")
+	cmd.Flags().StringVar(&onDemandProvisioningRoles, "onDemandProvisioningRoles", "", "Sumo Logic RBAC roles to be assigned when user accounts are provisioned"+
+		"(the roles need to be comma separated e.g. role1,role2,role3)")
+	cmd.Flags().StringVar(&rolesAttribute, "rolesAttribute", "", "Specify the role that Sumo Logic will assign to users when they sign in")
+	cmd.Flags().BoolVar(&logoutEnabled, "logoutEnabled", false, "Set to true if users are redirected to a URL after signing out of Sumo Logic")
+	cmd.Flags().StringVar(&logoutUrl, "logoutUrl", "", "Specify the URL that users will be redirected to after signing out of Sumo Logic")
+	cmd.Flags().StringVar(&emailAttribute, "emailAttribute", "", "Specify the email address of the new user account.")
+	cmd.Flags().BoolVar(&debugMode, "debugMode", false, "Set to true if additional details are included when a user fails to sign in")
+	cmd.Flags().BoolVar(&signAuthnRequest, "signAuthnRequest", false, "Set to true if Sumo Logic will send signed Authn requests to the identity provider")
+	cmd.Flags().BoolVar(&disableRequestAuthnContext, "disableRequestAuthnContext", false, "Set to true if Sumo Logic will include the RequestedAuthnContext element of the SAML AuthnRequests it sends to the identity provider")
+	cmd.Flags().BoolVar(&isRedirectBinding, "isRedirectBinding", false, "Set to true if the SAML binding is of HTTP Redirect type")
+	cmd.MarkFlagRequired("configurationName")
+	cmd.MarkFlagRequired("issuer")
+	cmd.MarkFlagRequired("x509cert1")
+	return cmd
+}
+
+func createSamlConfiguration() {
+
+}

--- a/pkg/cmd/saml/delete-configuration/delete-configuration.go
+++ b/pkg/cmd/saml/delete-configuration/delete-configuration.go
@@ -1,0 +1,52 @@
+package delete_configuration
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdSamlDeleteConfiguration() *cobra.Command {
+	var id string
+
+	cmd := &cobra.Command{
+		Use:   "delete-configuration",
+		Short: "Delete a SAML configuration with the given identifier from the organization.",
+		Run: func(cmd *cobra.Command, args []string) {
+			deleteSamlConfiguration(id)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the SAML configuration")
+	cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+func deleteSamlConfiguration(id string) {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/saml/identityProviders/" + id
+	client, request := factory.NewHttpRequest("DELETE", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("The SAML configuration was deleted successfully.")
+	}
+}

--- a/pkg/cmd/saml/disable-lockdown/disable-lockdown.go
+++ b/pkg/cmd/saml/disable-lockdown/disable-lockdown.go
@@ -1,0 +1,48 @@
+package disable_lockdown
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdSamlDisableLockdown() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disable-lockdown",
+		Short: "Disable SAML lockdown for the organization.",
+		Run: func(cmd *cobra.Command, args []string) {
+			disableSamlLockdown()
+		},
+	}
+	return cmd
+}
+
+func disableSamlLockdown() {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/saml/lockdown/disable"
+	client, request := factory.NewHttpRequest("POST", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("SAML lockdown was disabled successfully.")
+	}
+}

--- a/pkg/cmd/saml/enable-lockdown/enable-lockdown.go
+++ b/pkg/cmd/saml/enable-lockdown/enable-lockdown.go
@@ -1,0 +1,48 @@
+package enable_lockdown
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdSamlEnableLockdown() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable-lockdown",
+		Short: "Enabling SAML lockdown requires users to sign in using SAML preventing them from logging in with an email and password.",
+		Run: func(cmd *cobra.Command, args []string) {
+			enableSamlLockdown()
+		},
+	}
+	return cmd
+}
+
+func enableSamlLockdown() {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/saml/lockdown/enable"
+	client, request := factory.NewHttpRequest("POST", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("SAML lockdown was enabled successfully.")
+	}
+}

--- a/pkg/cmd/saml/get-allowlist-users/get-allowlist-users.go
+++ b/pkg/cmd/saml/get-allowlist-users/get-allowlist-users.go
@@ -1,0 +1,55 @@
+package get_allowlist_users
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdSamlGetAllowListUsers() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-allowlist-users",
+		Short: "Get a list of allowlisted users.",
+		Run: func(cmd *cobra.Command, args []string) {
+			getAllowListUsers()
+		},
+	}
+	return cmd
+}
+
+func getAllowListUsers() {
+	var allowListResponse []api.GetSamlAllowListUsers
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/saml/allowlistedUsers"
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &allowListResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	allowListResponseJson, err := json.MarshalIndent(allowListResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(allowListResponseJson))
+	}
+}

--- a/pkg/cmd/saml/get-configurations/get-configurations.go
+++ b/pkg/cmd/saml/get-configurations/get-configurations.go
@@ -1,0 +1,55 @@
+package get_configurations
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdSamlGetConfigurations() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-configurations",
+		Short: "Get a list of all SAML configurations in the organization.",
+		Run: func(cmd *cobra.Command, args []string) {
+			getSaml()
+		},
+	}
+	return cmd
+}
+
+func getSaml() {
+	var samlResponse []api.GetSaml
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/saml/identityProviders"
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	err = json.Unmarshal(responseBody, &samlResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal response body")
+	}
+
+	samlResponseJson, err := json.MarshalIndent(samlResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal response")
+	}
+
+	if response.StatusCode != 200 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(samlResponseJson))
+	}
+}

--- a/pkg/cmd/saml/remove-allowlist-user/remove-allowlist-user.go
+++ b/pkg/cmd/saml/remove-allowlist-user/remove-allowlist-user.go
@@ -1,0 +1,52 @@
+package remove_allowlist_user
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+)
+
+func NewCmdSamlRemoveAllowListUser() *cobra.Command {
+	var userId string
+
+	cmd := &cobra.Command{
+		Use:   "remove-allowlist-user",
+		Short: "Remove an allowlisted user requiring them to sign in using SAML.",
+		Run: func(cmd *cobra.Command, args []string) {
+			removeAllowListUser(userId)
+		},
+	}
+	cmd.Flags().StringVar(&userId, "userId", "", "Specify the id of the user")
+	cmd.MarkFlagRequired("userId")
+	return cmd
+}
+
+func removeAllowListUser(userId string) {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/saml/allowlistedUsers/" + userId
+	client, request := factory.NewHttpRequest("DELETE", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request to " + requestUrl)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
+	}
+
+	if response.StatusCode != 204 {
+		var responseError api.ResponseError
+		err := json.Unmarshal(responseBody, &responseError)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+	} else {
+		fmt.Println("User was successfully removed form the allowlist for SAML lockdown.")
+	}
+}

--- a/pkg/cmd/saml/saml.go
+++ b/pkg/cmd/saml/saml.go
@@ -3,12 +3,14 @@ package saml
 import (
 	"github.com/spf13/cobra"
 	NewCmdSamlAddAllowListUser "github.com/wizedkyle/sumocli/pkg/cmd/saml/add-allowlist-user"
+	NewCmdSamlCreateConfiguration "github.com/wizedkyle/sumocli/pkg/cmd/saml/create-configuration"
 	NewCmdSamlDeleteConfiguration "github.com/wizedkyle/sumocli/pkg/cmd/saml/delete-configuration"
 	NewCmdSamlDisableLockdown "github.com/wizedkyle/sumocli/pkg/cmd/saml/disable-lockdown"
 	NewCmdSamlEnableLockdown "github.com/wizedkyle/sumocli/pkg/cmd/saml/enable-lockdown"
 	NewCmdSamlGetAllowListUsers "github.com/wizedkyle/sumocli/pkg/cmd/saml/get-allowlist-users"
 	NewCmdSamlGetConfigurations "github.com/wizedkyle/sumocli/pkg/cmd/saml/get-configurations"
 	NewCmdSamlRemoveAllowListUser "github.com/wizedkyle/sumocli/pkg/cmd/saml/remove-allowlist-user"
+	NewCmdSamlUpdateConfiguration "github.com/wizedkyle/sumocli/pkg/cmd/saml/update-configuration"
 )
 
 func NewCmdSaml() *cobra.Command {
@@ -18,11 +20,13 @@ func NewCmdSaml() *cobra.Command {
 		Long:  "Commands that allow you to manage the SAML configurations in your Sumo Logic tenant",
 	}
 	cmd.AddCommand(NewCmdSamlAddAllowListUser.NewCmdSamlAddAllowListUser())
+	cmd.AddCommand(NewCmdSamlCreateConfiguration.NewCmdSamlCreateConfiguration())
 	cmd.AddCommand(NewCmdSamlDeleteConfiguration.NewCmdSamlDeleteConfiguration())
 	cmd.AddCommand(NewCmdSamlDisableLockdown.NewCmdSamlDisableLockdown())
 	cmd.AddCommand(NewCmdSamlEnableLockdown.NewCmdSamlEnableLockdown())
 	cmd.AddCommand(NewCmdSamlGetAllowListUsers.NewCmdSamlGetAllowListUsers())
 	cmd.AddCommand(NewCmdSamlGetConfigurations.NewCmdSamlGetConfigurations())
 	cmd.AddCommand(NewCmdSamlRemoveAllowListUser.NewCmdSamlRemoveAllowListUser())
+	cmd.AddCommand(NewCmdSamlUpdateConfiguration.NewCmdSamlUpdateConfiguration())
 	return cmd
 }

--- a/pkg/cmd/saml/saml.go
+++ b/pkg/cmd/saml/saml.go
@@ -1,0 +1,16 @@
+package saml
+
+import (
+	"github.com/spf13/cobra"
+	NewCmdSamlGetConfigurations "github.com/wizedkyle/sumocli/pkg/cmd/saml/get-configurations"
+)
+
+func NewCmdSaml() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "saml",
+		Short: "Manage SAML configuration",
+		Long:  "Commands that allow you to manage the SAML configurations in your Sumo Logic tenant",
+	}
+	cmd.AddCommand(NewCmdSamlGetConfigurations.NewCmdSamlGetConfigurations())
+	return cmd
+}

--- a/pkg/cmd/saml/saml.go
+++ b/pkg/cmd/saml/saml.go
@@ -2,7 +2,13 @@ package saml
 
 import (
 	"github.com/spf13/cobra"
+	NewCmdSamlAddAllowListUser "github.com/wizedkyle/sumocli/pkg/cmd/saml/add-allowlist-user"
+	NewCmdSamlDeleteConfiguration "github.com/wizedkyle/sumocli/pkg/cmd/saml/delete-configuration"
+	NewCmdSamlDisableLockdown "github.com/wizedkyle/sumocli/pkg/cmd/saml/disable-lockdown"
+	NewCmdSamlEnableLockdown "github.com/wizedkyle/sumocli/pkg/cmd/saml/enable-lockdown"
+	NewCmdSamlGetAllowListUsers "github.com/wizedkyle/sumocli/pkg/cmd/saml/get-allowlist-users"
 	NewCmdSamlGetConfigurations "github.com/wizedkyle/sumocli/pkg/cmd/saml/get-configurations"
+	NewCmdSamlRemoveAllowListUser "github.com/wizedkyle/sumocli/pkg/cmd/saml/remove-allowlist-user"
 )
 
 func NewCmdSaml() *cobra.Command {
@@ -11,6 +17,12 @@ func NewCmdSaml() *cobra.Command {
 		Short: "Manage SAML configuration",
 		Long:  "Commands that allow you to manage the SAML configurations in your Sumo Logic tenant",
 	}
+	cmd.AddCommand(NewCmdSamlAddAllowListUser.NewCmdSamlAddAllowListUser())
+	cmd.AddCommand(NewCmdSamlDeleteConfiguration.NewCmdSamlDeleteConfiguration())
+	cmd.AddCommand(NewCmdSamlDisableLockdown.NewCmdSamlDisableLockdown())
+	cmd.AddCommand(NewCmdSamlEnableLockdown.NewCmdSamlEnableLockdown())
+	cmd.AddCommand(NewCmdSamlGetAllowListUsers.NewCmdSamlGetAllowListUsers())
 	cmd.AddCommand(NewCmdSamlGetConfigurations.NewCmdSamlGetConfigurations())
+	cmd.AddCommand(NewCmdSamlRemoveAllowListUser.NewCmdSamlRemoveAllowListUser())
 	return cmd
 }

--- a/pkg/cmd/saml/update-configuration/update-configuration.go
+++ b/pkg/cmd/saml/update-configuration/update-configuration.go
@@ -1,0 +1,1 @@
+package update_configuration

--- a/pkg/cmd/saml/update-configuration/update-configuration.go
+++ b/pkg/cmd/saml/update-configuration/update-configuration.go
@@ -1,1 +1,308 @@
 package update_configuration
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+func NewCmdSamlUpdateConfiguration() *cobra.Command {
+	var (
+		spInitiatedLoginPath       string
+		configurationName          string
+		issuer                     string
+		spInitiatedLoginEnabled    bool
+		authnRequestUrl            string
+		x509cert1                  string
+		x509cert2                  string
+		x509cert3                  string
+		firstNameAttribute         string
+		lastNameAttribute          string
+		onDemandProvisioningRoles  []string
+		rolesAttribute             string
+		logoutEnabled              bool
+		logoutUrl                  string
+		emailAttribute             string
+		debugMode                  bool
+		signAuthnRequest           bool
+		disableRequestAuthnContext bool
+		isRedirectBinding          bool
+		id                         string
+		merge                      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update-configuration",
+		Short: "Update an existing SAML configuration in the organization.",
+		Run: func(cmd *cobra.Command, args []string) {
+			updateSamlConfiguration(spInitiatedLoginPath, configurationName, issuer, spInitiatedLoginEnabled,
+				authnRequestUrl, x509cert1, x509cert2, x509cert3, firstNameAttribute, lastNameAttribute, onDemandProvisioningRoles,
+				rolesAttribute, logoutEnabled, logoutUrl, emailAttribute, debugMode, signAuthnRequest,
+				disableRequestAuthnContext, isRedirectBinding, id, merge)
+		},
+	}
+	cmd.Flags().StringVar(&spInitiatedLoginPath, "spInitiatedLoginPath", "", "Specify the identifier used to generate a unique URL for user login")
+	cmd.Flags().StringVar(&configurationName, "configurationName", "", "Specify the name of the SSO policy or another name used to described the policy internally")
+	cmd.Flags().StringVar(&issuer, "issuer", "", "Specify the unique URL assigned to the organization by the SAML Identity Provider")
+	cmd.Flags().BoolVar(&spInitiatedLoginEnabled, "spInitiatedLoginEnabled", false, "Set to true if Sumo Logic redirects users to your identity provider with a SAML AuthnRequest when signing in")
+	cmd.Flags().StringVar(&authnRequestUrl, "authnRequestUrl", "", "Specify the URL that the identity provider has assigned for Sumo Logic to submit SAML authentication requests to the identity provider")
+	cmd.Flags().StringVar(&x509cert1, "x509cert1", "", "Specify the certificate that is used to verify the signature in SAML assertions")
+	cmd.Flags().StringVar(&x509cert2, "x509cert2", "", "Specify a backup certificate used to verify the signature in SAML assertions when x509cert1 expires (optional)")
+	cmd.Flags().StringVar(&x509cert3, "x509cert3", "", "Specify a backup certificate used to verify the signature in SAML assertions when x509cert1 expires and x509cert2 is empty (optional)")
+	cmd.Flags().StringVar(&firstNameAttribute, "firstNameAttribute", "", "Specify the first name attribute of the new user account")
+	cmd.Flags().StringVar(&lastNameAttribute, "lastNameAttribute", "", "Specify the last name attribute of the new user account")
+	cmd.Flags().StringSliceVar(&onDemandProvisioningRoles, "onDemandProvisioningRoles", []string{}, "Sumo Logic RBAC roles to be assigned when user accounts are provisioned"+
+		"(the roles need to be comma separated e.g. role1,role2,role3)")
+	cmd.Flags().StringVar(&rolesAttribute, "rolesAttribute", "", "Specify the role that Sumo Logic will assign to users when they sign in")
+	cmd.Flags().BoolVar(&logoutEnabled, "logoutEnabled", false, "Set to true if users are redirected to a URL after signing out of Sumo Logic")
+	cmd.Flags().StringVar(&logoutUrl, "logoutUrl", "", "Specify the URL that users will be redirected to after signing out of Sumo Logic")
+	cmd.Flags().StringVar(&emailAttribute, "emailAttribute", "", "Specify the email address of the new user account.")
+	cmd.Flags().BoolVar(&debugMode, "debugMode", false, "Set to true if additional details are included when a user fails to sign in")
+	cmd.Flags().BoolVar(&signAuthnRequest, "signAuthnRequest", false, "Set to true if Sumo Logic will send signed Authn requests to the identity provider")
+	cmd.Flags().BoolVar(&disableRequestAuthnContext, "disableRequestAuthnContext", false, "Set to true if Sumo Logic will include the RequestedAuthnContext element of the SAML AuthnRequests it sends to the identity provider")
+	cmd.Flags().BoolVar(&isRedirectBinding, "isRedirectBinding", false, "Set to true if the SAML binding is of HTTP Redirect type")
+	cmd.Flags().StringVar(&id, "id", "", "Specify the id of the SAML configuration")
+	cmd.Flags().BoolVar(&merge, "merge", true, "If set to false it will overwrite the ingest budget configuration")
+	cmd.MarkFlagRequired("configurationName")
+	cmd.MarkFlagRequired("id")
+	cmd.MarkFlagRequired("issuer")
+	cmd.MarkFlagRequired("x509cert1")
+	return cmd
+}
+
+func updateSamlConfiguration(spInitiatedLoginPath string, configurationName string, issuer string, spInitiatedLoginEnabled bool,
+	authnRequestUrl string, x509cert1 string, x509cert2 string, x509cert3 string, firstNameAttribute string, lastNameAttribute string,
+	onDemandProvisioningRoles []string, rolesAttribute string, logoutEnabled bool, logoutUrl string, emailAttribute string,
+	debugMode bool, signAuthnRequest bool, disableRequestAuthnContext bool, isRedirectBinding bool, id string, merge bool) {
+	var samlResponse api.GetSaml
+	log := logging.GetConsoleLogger()
+	if merge == true {
+		requestUrl := "v1/saml/identityProviders/" + id
+		client, request := factory.NewHttpRequest("GET", requestUrl)
+		response, err := client.Do(request)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to make http request " + requestUrl)
+		}
+		defer response.Body.Close()
+		responseBody, err := io.ReadAll(response.Body)
+		if err != nil {
+			log.Error().Err(err).Msg("error reading response body from request")
+		}
+		err = json.Unmarshal(responseBody, &samlResponse)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+		if response.StatusCode != 200 {
+			log.Fatal().Msg("Error code = " + strconv.Itoa(response.StatusCode) + string(responseBody))
+		}
+
+		// Building body payload to update the saml configuration based on differences
+		// between the current saml configuration and the desired settings
+		requestBodySchema := &api.CreateSamlRequest{}
+		if strings.EqualFold(samlResponse.SpInitiatedLoginPath, spInitiatedLoginPath) {
+			requestBodySchema.SpInitiatedLoginPath = samlResponse.SpInitiatedLoginPath
+		} else {
+			requestBodySchema.SpInitiatedLoginPath = spInitiatedLoginPath
+		}
+
+		if strings.EqualFold(samlResponse.ConfigurationName, configurationName) {
+			requestBodySchema.ConfigurationName = samlResponse.ConfigurationName
+		} else {
+			requestBodySchema.ConfigurationName = configurationName
+		}
+
+		if strings.EqualFold(samlResponse.Issuer, issuer) {
+			requestBodySchema.Issuer = samlResponse.Issuer
+		} else {
+			requestBodySchema.Issuer = issuer
+		}
+
+		if samlResponse.SpInitiatedLoginEnabled == spInitiatedLoginEnabled {
+			requestBodySchema.SpInitiatedLoginEnabled = samlResponse.SpInitiatedLoginEnabled
+		} else {
+			requestBodySchema.SpInitiatedLoginEnabled = spInitiatedLoginEnabled
+		}
+
+		if strings.EqualFold(samlResponse.AuthnRequestUrl, authnRequestUrl) {
+			requestBodySchema.AuthnRequestUrl = samlResponse.AuthnRequestUrl
+		} else {
+			requestBodySchema.AuthnRequestUrl = authnRequestUrl
+		}
+
+		if strings.EqualFold(samlResponse.X509Cert1, x509cert1) {
+			requestBodySchema.X509Cert1 = samlResponse.X509Cert1
+		} else {
+			requestBodySchema.X509Cert1 = x509cert1
+		}
+
+		if strings.EqualFold(samlResponse.X509Cert2, x509cert2) {
+			requestBodySchema.X509Cert2 = samlResponse.X509Cert2
+		} else {
+			requestBodySchema.X509Cert2 = x509cert2
+		}
+
+		if strings.EqualFold(samlResponse.X509Cert3, x509cert3) {
+			requestBodySchema.X509Cert3 = samlResponse.X509Cert3
+		} else {
+			requestBodySchema.X509Cert3 = x509cert3
+		}
+
+		if strings.EqualFold(samlResponse.OnDemandProvisioningEnabled.FirstNameAttribute, firstNameAttribute) {
+			requestBodySchema.OnDemandProvisioningEnabled.FirstNameAttribute = samlResponse.OnDemandProvisioningEnabled.FirstNameAttribute
+		} else {
+			requestBodySchema.OnDemandProvisioningEnabled.FirstNameAttribute = firstNameAttribute
+		}
+
+		if strings.EqualFold(samlResponse.OnDemandProvisioningEnabled.LastNameAttribute, lastNameAttribute) {
+			requestBodySchema.OnDemandProvisioningEnabled.LastNameAttribute = samlResponse.OnDemandProvisioningEnabled.LastNameAttribute
+		} else {
+			requestBodySchema.OnDemandProvisioningEnabled.LastNameAttribute = lastNameAttribute
+		}
+
+		if reflect.DeepEqual(samlResponse.OnDemandProvisioningEnabled.OnDemandProvisioningRoles, onDemandProvisioningRoles) {
+			requestBodySchema.OnDemandProvisioningEnabled.OnDemandProvisioningRoles = samlResponse.OnDemandProvisioningEnabled.OnDemandProvisioningRoles
+		} else {
+			requestBodySchema.OnDemandProvisioningEnabled.OnDemandProvisioningRoles = append(requestBodySchema.OnDemandProvisioningEnabled.OnDemandProvisioningRoles, samlResponse.OnDemandProvisioningEnabled.OnDemandProvisioningRoles...)
+			requestBodySchema.OnDemandProvisioningEnabled.OnDemandProvisioningRoles = append(requestBodySchema.OnDemandProvisioningEnabled.OnDemandProvisioningRoles, onDemandProvisioningRoles...)
+		}
+
+		if strings.EqualFold(samlResponse.RolesAttribute, rolesAttribute) {
+			requestBodySchema.RolesAttribute = samlResponse.RolesAttribute
+		} else {
+			requestBodySchema.RolesAttribute = rolesAttribute
+		}
+
+		if samlResponse.LogoutEnabled == logoutEnabled {
+			requestBodySchema.LogoutEnabled = samlResponse.LogoutEnabled
+		} else {
+			requestBodySchema.LogoutEnabled = logoutEnabled
+		}
+
+		if strings.EqualFold(samlResponse.LogoutUrl, logoutUrl) {
+			requestBodySchema.LogoutUrl = samlResponse.LogoutUrl
+		} else {
+			requestBodySchema.LogoutUrl = logoutUrl
+		}
+
+		if strings.EqualFold(samlResponse.EmailAttribute, emailAttribute) {
+			requestBodySchema.EmailAttribute = samlResponse.EmailAttribute
+		} else {
+			requestBodySchema.EmailAttribute = emailAttribute
+		}
+
+		if samlResponse.DebugMode == debugMode {
+			requestBodySchema.DebugMode = samlResponse.DebugMode
+		} else {
+			requestBodySchema.DebugMode = debugMode
+		}
+
+		if samlResponse.SignAuthnRequest == signAuthnRequest {
+			requestBodySchema.SignAuthnRequest = samlResponse.SignAuthnRequest
+		} else {
+			requestBodySchema.SignAuthnRequest = signAuthnRequest
+		}
+
+		if samlResponse.DisableRequestedAuthnContext == disableRequestAuthnContext {
+			requestBodySchema.DisableRequestedAuthnContext = samlResponse.DisableRequestedAuthnContext
+		} else {
+			requestBodySchema.DisableRequestedAuthnContext = disableRequestAuthnContext
+		}
+
+		if samlResponse.IsRedirectBinding == isRedirectBinding {
+			requestBodySchema.IsRedirectBinding = samlResponse.IsRedirectBinding
+		} else {
+			requestBodySchema.IsRedirectBinding = isRedirectBinding
+		}
+
+		requestBody, err := json.Marshal(requestBodySchema)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to marshal request body")
+		}
+		client, request = factory.NewHttpRequestWithBody("PUT", requestUrl, requestBody)
+		response, err = client.Do(request)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to make http request " + requestUrl)
+		}
+		defer response.Body.Close()
+		responseBody, err = io.ReadAll(response.Body)
+		if err != nil {
+			log.Error().Err(err).Msg("error reading response body from request")
+		}
+		err = json.Unmarshal(responseBody, &samlResponse)
+		if err != nil {
+			log.Error().Err(err).Msg("error unmarshalling response body")
+		}
+		samlResponseJson, err := json.MarshalIndent(samlResponse, "", "    ")
+		if err != nil {
+			log.Error().Err(err).Msg("error marshalling response body")
+		}
+		if response.StatusCode != 200 {
+			log.Error().Msg("Error code = " + strconv.Itoa(response.StatusCode) + string(responseBody))
+		} else {
+			fmt.Println(string(samlResponseJson))
+		}
+	} else {
+		requestBodySchema := &api.CreateSamlRequest{
+			SpInitiatedLoginPath:    spInitiatedLoginPath,
+			ConfigurationName:       configurationName,
+			Issuer:                  issuer,
+			SpInitiatedLoginEnabled: spInitiatedLoginEnabled,
+			AuthnRequestUrl:         authnRequestUrl,
+			X509Cert1:               x509cert1,
+			X509Cert2:               x509cert2,
+			X509Cert3:               x509cert3,
+			OnDemandProvisioningEnabled: api.OnDemandProvisioningDetail{
+				FirstNameAttribute:        firstNameAttribute,
+				LastNameAttribute:         lastNameAttribute,
+				OnDemandProvisioningRoles: onDemandProvisioningRoles,
+			},
+			RolesAttribute:               rolesAttribute,
+			LogoutEnabled:                logoutEnabled,
+			LogoutUrl:                    logoutUrl,
+			EmailAttribute:               emailAttribute,
+			DebugMode:                    debugMode,
+			SignAuthnRequest:             signAuthnRequest,
+			DisableRequestedAuthnContext: disableRequestAuthnContext,
+			IsRedirectBinding:            isRedirectBinding,
+		}
+		requestBody, err := json.Marshal(requestBodySchema)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to marshal request body")
+		}
+		requestUrl := "v1/saml/identityProviders/" + id
+		client, request := factory.NewHttpRequestWithBody("PUT", requestUrl, requestBody)
+		response, err := client.Do(request)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to make http request")
+		}
+
+		defer response.Body.Close()
+		responseBody, err := io.ReadAll(response.Body)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to read response body")
+		}
+
+		err = json.Unmarshal(responseBody, &samlResponse)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to unmarshal response body")
+		}
+
+		samlResponseJson, err := json.MarshalIndent(samlResponse, "", "    ")
+		if err != nil {
+			log.Error().Err(err).Msg("failed to marshal lookupTableResponse")
+		}
+
+		if response.StatusCode != 200 {
+			factory.HttpError(response.StatusCode, responseBody, log)
+		} else {
+			fmt.Println(string(samlResponseJson))
+		}
+	}
+}

--- a/pkg/cmd/sources/delete/delete.go
+++ b/pkg/cmd/sources/delete/delete.go
@@ -1,0 +1,1 @@
+package delete

--- a/pkg/cmd/sources/delete/delete.go
+++ b/pkg/cmd/sources/delete/delete.go
@@ -1,1 +1,46 @@
 package delete
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"strconv"
+)
+
+func NewCmdDeleteSource() *cobra.Command {
+	var (
+		collectorId int
+		sourceId    int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Deletes the specified Source from the specified Collector.",
+		Run: func(cmd *cobra.Command, args []string) {
+			deleteSource(collectorId, sourceId)
+		},
+	}
+	cmd.Flags().IntVar(&collectorId, "collectorId", 0, "Specify the collector id the source is associated with")
+	cmd.Flags().IntVar(&sourceId, "sourceId", 0, "Specify the source Id to delete")
+	cmd.MarkFlagRequired("collectorId")
+	cmd.MarkFlagRequired("sourceId")
+	return cmd
+}
+
+func deleteSource(collectorId int, sourceId int) {
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/collectors/" + strconv.Itoa(collectorId) + "/sources/" + strconv.Itoa(sourceId)
+	client, request := factory.NewHttpRequest("DELETE", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	if response.StatusCode != 200 {
+		fmt.Println("source with id " + strconv.Itoa(sourceId) + " failed to delete, please try again.")
+	} else {
+		fmt.Println("source with id " + strconv.Itoa(sourceId) + " has been deleted")
+	}
+}

--- a/pkg/cmd/sources/http/create/create.go
+++ b/pkg/cmd/sources/http/create/create.go
@@ -1,0 +1,104 @@
+package create
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+	"strconv"
+	"strings"
+)
+
+func NewCmdCreateHttpSource() *cobra.Command {
+	var (
+		category                   string
+		collectorId                int
+		fieldNames                 string
+		fieldValues                string
+		messagePerRequest          bool
+		multilineProcessingEnabled bool
+		name                       string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Creates a HTTP source on the specified Sumo Logic collector",
+		Run: func(cmd *cobra.Command, args []string) {
+			createHttpSource(category, collectorId, fieldNames, fieldValues, messagePerRequest,
+				multilineProcessingEnabled, name)
+		},
+	}
+	cmd.Flags().StringVar(&category, "category", "", "Specify the sourceCategory for the source")
+	cmd.Flags().IntVar(&collectorId, "collectorId", 0, "Specify the collector id to associate the source to")
+	cmd.Flags().StringVar(&fieldNames, "fieldNames", "", "Specify the names of fields to add to the source "+
+		"{names need to be comma separated e.g. field1,field2")
+	cmd.Flags().StringVar(&fieldValues, "fieldValues", "", "Specify the values of fields to add to the source "+
+		"(values need to be comma separated e.g. value1,value2")
+	cmd.Flags().BoolVar(&messagePerRequest, "messagePerRequest", false, "Specify if there is one message per request")
+	cmd.Flags().BoolVar(&multilineProcessingEnabled, "multilineProcessingEnabled", false, "Specify if multiline processing is enabled")
+	cmd.Flags().StringVar(&name, "name", "", "Specify the name of the source")
+	cmd.MarkFlagRequired("collectorId")
+	cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func createHttpSource(category string, collectorId int, fieldNames string, fieldValues string,
+	messagePerRequest bool, multilineProcessingEnabled bool, name string) {
+	var sourceResponse api.CreateSourceResponse
+	log := logging.GetConsoleLogger()
+	requestUrl := "v1/collectors/" + strconv.Itoa(collectorId) + "/sources"
+	fieldsMap := make(map[string]string)
+	if fieldNames != "" && fieldValues != "" {
+		fieldNamesSlice := strings.Split(fieldNames, ",")
+		fieldValuesSlice := strings.Split(fieldValues, ",")
+		for i, _ := range fieldNamesSlice {
+			fieldsMap[fieldNamesSlice[i]] = fieldValuesSlice[i]
+			i++
+		}
+	}
+	requestBodySchema := &api.CreateHTTPSource{
+		ApiVersion: "v1",
+		Source: api.HttpSource{
+			SourceType:                 "HTTP",
+			Name:                       name,
+			Category:                   category,
+			Fields:                     fieldsMap,
+			MessagePerRequest:          messagePerRequest,
+			MultilineProcessingEnabled: multilineProcessingEnabled,
+		},
+	}
+	requestBody, err := json.Marshal(requestBodySchema)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal request body")
+	}
+	client, request := factory.NewHttpRequestWithBody("POST", requestUrl, requestBody)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request")
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("error reading response body from request")
+	}
+
+	err = json.Unmarshal(responseBody, &sourceResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("error unmarshalling response body")
+	}
+
+	sourceResponseJson, err := json.MarshalIndent(sourceResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal lookupTableResponse")
+	}
+
+	if response.StatusCode != 201 {
+		factory.HttpError(response.StatusCode, responseBody, log)
+	} else {
+		fmt.Println(string(sourceResponseJson))
+	}
+}

--- a/pkg/cmd/sources/http/http.go
+++ b/pkg/cmd/sources/http/http.go
@@ -1,0 +1,15 @@
+package http
+
+import (
+	"github.com/spf13/cobra"
+	NewCmdCreateHttpSource "github.com/wizedkyle/sumocli/pkg/cmd/sources/http/create"
+)
+
+func NewCmdHttpSources() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "http <command>",
+		Short: "Manage https sources",
+	}
+	cmd.AddCommand(NewCmdCreateHttpSource.NewCmdCreateHttpSource())
+	return cmd
+}

--- a/pkg/cmd/sources/http/http.go
+++ b/pkg/cmd/sources/http/http.go
@@ -3,6 +3,7 @@ package http
 import (
 	"github.com/spf13/cobra"
 	NewCmdCreateHttpSource "github.com/wizedkyle/sumocli/pkg/cmd/sources/http/create"
+	NewCmdUpdateHttpSource "github.com/wizedkyle/sumocli/pkg/cmd/sources/http/update"
 )
 
 func NewCmdHttpSources() *cobra.Command {
@@ -11,5 +12,6 @@ func NewCmdHttpSources() *cobra.Command {
 		Short: "Manage https sources",
 	}
 	cmd.AddCommand(NewCmdCreateHttpSource.NewCmdCreateHttpSource())
+	cmd.AddCommand(NewCmdUpdateHttpSource.NewCmdUpdateHttpSource())
 	return cmd
 }

--- a/pkg/cmd/sources/http/update/update.go
+++ b/pkg/cmd/sources/http/update/update.go
@@ -1,10 +1,16 @@
 package update
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/cmd/factory"
 	"github.com/wizedkyle/sumocli/pkg/logging"
+	"io"
+	"reflect"
 	"strconv"
+	"strings"
 )
 
 func NewCmdUpdateHttpSource() *cobra.Command {
@@ -17,14 +23,14 @@ func NewCmdUpdateHttpSource() *cobra.Command {
 		multilineProcessingEnabled bool
 		name                       string
 		sourceId                   string
-		merge                      bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update a specific HTTP source on the specified Sumo Logic collector",
 		Run: func(cmd *cobra.Command, args []string) {
-
+			updateHttpSource(category, collectorId, fieldNames, fieldValues, messagePerRequest,
+				multilineProcessingEnabled, name, sourceId)
 		},
 	}
 	cmd.Flags().StringVar(&category, "category", "", "Specify the sourceCategory for the source")
@@ -37,20 +43,118 @@ func NewCmdUpdateHttpSource() *cobra.Command {
 	cmd.Flags().BoolVar(&multilineProcessingEnabled, "multilineProcessingEnabled", false, "Specify if multiline processing is enabled")
 	cmd.Flags().StringVar(&name, "name", "", "Specify the name of the source")
 	cmd.Flags().StringVar(&sourceId, "sourceId", "", "Specify the source Id to update")
-	cmd.Flags().BoolVar(&merge, "merge", true, "")
 	cmd.MarkFlagRequired("collectorId")
 	cmd.MarkFlagRequired("name")
 	return cmd
 }
 
-func updateHttpSource(category string, collectorId int, fieldName string, fieldValues string,
-	messagePerRequest bool, multilineProcessingEnabled bool, name string, sourceId string, merge bool) {
-	var sourceResponse api.SourcesResponse
+func updateHttpSource(category string, collectorId int, fieldNames string, fieldValues string,
+	messagePerRequest bool, multilineProcessingEnabled bool, name string, sourceId string) {
+	var sourceResponse api.CreateSourceResponse
 	log := logging.GetConsoleLogger()
-	if merge == true {
-		requestUrl := "v1/collectors/" + strconv.Itoa(collectorId) + "/sources/" + sourceId
 
+	requestUrl := "v1/collectors/" + strconv.Itoa(collectorId) + "/sources/" + sourceId
+	client, request := factory.NewHttpRequest("GET", requestUrl)
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request " + requestUrl)
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("error reading response body from request")
+	}
+	etag := response.Header.Values("Etag")
+	err = json.Unmarshal(responseBody, &sourceResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("error unmarshalling response body")
+	}
+	if response.StatusCode != 200 {
+		log.Fatal().Msg("Error code = " + strconv.Itoa(response.StatusCode) + string(responseBody))
+	}
+
+	// Building body payload to update the source based on the differences
+	// between the current source and the desired settings
+	fieldsMap := make(map[string]string)
+	if fieldNames != "" && fieldValues != "" {
+		fieldNamesSlice := strings.Split(fieldNames, ",")
+		fieldValuesSlice := strings.Split(fieldValues, ",")
+		for i, _ := range fieldNamesSlice {
+			fieldsMap[fieldNamesSlice[i]] = fieldValuesSlice[i]
+			i++
+		}
+	}
+	requestBodySchema := &api.CreateSourceResponse{}
+	if sourceResponse.Source.Category == category {
+		requestBodySchema.Source.Category = sourceResponse.Source.Category
 	} else {
+		requestBodySchema.Source.Category = category
+	}
 
+	if reflect.DeepEqual(sourceResponse.Source.Fields, fieldsMap) {
+		requestBodySchema.Source.Fields = sourceResponse.Source.Fields
+	} else {
+		requestBodySchema.Source.Fields = fieldsMap
+	}
+
+	if sourceResponse.Source.MessagePerRequest == messagePerRequest {
+		requestBodySchema.Source.MessagePerRequest = sourceResponse.Source.MessagePerRequest
+	} else {
+		requestBodySchema.Source.MessagePerRequest = messagePerRequest
+	}
+
+	if sourceResponse.Source.MultilineProcessingEnabled == multilineProcessingEnabled {
+		requestBodySchema.Source.MultilineProcessingEnabled = sourceResponse.Source.MultilineProcessingEnabled
+	} else {
+		requestBodySchema.Source.MultilineProcessingEnabled = multilineProcessingEnabled
+	}
+
+	if sourceResponse.Source.Name == name {
+		requestBodySchema.Source.Name = sourceResponse.Source.Name
+	} else {
+		requestBodySchema.Source.Name = name
+	}
+	requestBodySchema.Source.Id = sourceResponse.Source.Id
+	requestBodySchema.Source.Alive = sourceResponse.Source.Alive
+	requestBodySchema.Source.AutomaticDateParsing = sourceResponse.Source.AutomaticDateParsing
+	requestBodySchema.Source.CutoffTimestamp = sourceResponse.Source.CutoffTimestamp
+	requestBodySchema.Source.Encoding = sourceResponse.Source.Encoding
+	requestBodySchema.Source.Filters = sourceResponse.Source.Filters
+	requestBodySchema.Source.ForceTimezone = sourceResponse.Source.ForceTimezone
+	requestBodySchema.Source.HostName = sourceResponse.Source.HostName
+	requestBodySchema.Source.Interval = sourceResponse.Source.Interval
+	requestBodySchema.Source.Metrics = sourceResponse.Source.Metrics
+	requestBodySchema.Source.SourceType = sourceResponse.Source.SourceType
+	requestBodySchema.Source.UseAutolineMatching = sourceResponse.Source.UseAutolineMatching
+	requestBody, err := json.Marshal(requestBodySchema)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal request body")
+	}
+	client, request = factory.NewHttpRequestWithBody("PUT", requestUrl, requestBody)
+	request.Header.Add("If-Match", etag[0])
+	response, err = client.Do(request)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to make http request " + requestUrl)
+	}
+	defer response.Body.Close()
+	responseBody, err = io.ReadAll(response.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("error reading response body from request")
+	}
+
+	err = json.Unmarshal(responseBody, &sourceResponse)
+	if err != nil {
+		log.Error().Err(err).Msg("error unmarshalling response body")
+	}
+
+	sourceResponseJson, err := json.MarshalIndent(&sourceResponse, "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msg("error marshalling response body")
+	}
+
+	if response.StatusCode != 200 {
+		log.Error().Msg("Error code = " + strconv.Itoa(response.StatusCode) + string(responseBody))
+	} else {
+		fmt.Println(string(sourceResponseJson))
 	}
 }

--- a/pkg/cmd/sources/http/update/update.go
+++ b/pkg/cmd/sources/http/update/update.go
@@ -1,0 +1,56 @@
+package update
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wizedkyle/sumocli/api"
+	"github.com/wizedkyle/sumocli/pkg/logging"
+	"strconv"
+)
+
+func NewCmdUpdateHttpSource() *cobra.Command {
+	var (
+		category                   string
+		collectorId                int
+		fieldNames                 string
+		fieldValues                string
+		messagePerRequest          bool
+		multilineProcessingEnabled bool
+		name                       string
+		sourceId                   string
+		merge                      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a specific HTTP source on the specified Sumo Logic collector",
+		Run: func(cmd *cobra.Command, args []string) {
+
+		},
+	}
+	cmd.Flags().StringVar(&category, "category", "", "Specify the sourceCategory for the source")
+	cmd.Flags().IntVar(&collectorId, "collectorId", 0, "Specify the collector id the source is associated with")
+	cmd.Flags().StringVar(&fieldNames, "fieldNames", "", "Specify the names of fields to add to the source "+
+		"{names need to be comma separated e.g. field1,field2")
+	cmd.Flags().StringVar(&fieldValues, "fieldValues", "", "Specify the values of fields to add to the source "+
+		"(values need to be comma separated e.g. value1,value2")
+	cmd.Flags().BoolVar(&messagePerRequest, "messagePerRequest", false, "Specify if there is one message per request")
+	cmd.Flags().BoolVar(&multilineProcessingEnabled, "multilineProcessingEnabled", false, "Specify if multiline processing is enabled")
+	cmd.Flags().StringVar(&name, "name", "", "Specify the name of the source")
+	cmd.Flags().StringVar(&sourceId, "sourceId", "", "Specify the source Id to update")
+	cmd.Flags().BoolVar(&merge, "merge", true, "")
+	cmd.MarkFlagRequired("collectorId")
+	cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func updateHttpSource(category string, collectorId int, fieldName string, fieldValues string,
+	messagePerRequest bool, multilineProcessingEnabled bool, name string, sourceId string, merge bool) {
+	var sourceResponse api.SourcesResponse
+	log := logging.GetConsoleLogger()
+	if merge == true {
+		requestUrl := "v1/collectors/" + strconv.Itoa(collectorId) + "/sources/" + sourceId
+
+	} else {
+
+	}
+}

--- a/pkg/cmd/sources/list/list.go
+++ b/pkg/cmd/sources/list/list.go
@@ -18,7 +18,7 @@ func NewCmdSourceList() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Lists sources on assigned to a Sumo Logic collector",
+		Short: "Lists sources assigned to a Sumo Logic collector",
 		Run: func(cmd *cobra.Command, args []string) {
 			log := logging.GetConsoleLogger()
 			listSources(collectorId, log)

--- a/pkg/cmd/sources/sources.go
+++ b/pkg/cmd/sources/sources.go
@@ -2,17 +2,16 @@ package sources
 
 import (
 	"github.com/spf13/cobra"
-	cmdSourcesCreate "github.com/wizedkyle/sumocli/pkg/cmd/sources/create"
+	cmdHttpSources "github.com/wizedkyle/sumocli/pkg/cmd/sources/http"
 	cmdSourcesList "github.com/wizedkyle/sumocli/pkg/cmd/sources/list"
 )
 
 func NewCmdSources() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "sources <command>",
+		Use:   "sources",
 		Short: "Manages sources assigned to collectors",
 	}
-
-	cmd.AddCommand(cmdSourcesCreate.NewCmdCreateSource())
+	cmd.AddCommand(cmdHttpSources.NewCmdHttpSources())
 	cmd.AddCommand(cmdSourcesList.NewCmdSourceList())
 	return cmd
 }

--- a/pkg/cmd/sources/sources.go
+++ b/pkg/cmd/sources/sources.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"github.com/spf13/cobra"
+	cmdSourcesDelete "github.com/wizedkyle/sumocli/pkg/cmd/sources/delete"
 	cmdHttpSources "github.com/wizedkyle/sumocli/pkg/cmd/sources/http"
 	cmdSourcesList "github.com/wizedkyle/sumocli/pkg/cmd/sources/list"
 )
@@ -11,6 +12,7 @@ func NewCmdSources() *cobra.Command {
 		Use:   "sources",
 		Short: "Manages sources assigned to collectors",
 	}
+	cmd.AddCommand(cmdSourcesDelete.NewCmdDeleteSource())
 	cmd.AddCommand(cmdHttpSources.NewCmdHttpSources())
 	cmd.AddCommand(cmdSourcesList.NewCmdSourceList())
 	return cmd


### PR DESCRIPTION
# Description

This PR adds support for the following APIs:
- Account
- Password Policy
- SAML
- Ingest Budgets
- Ingest Budgets v2

Sources commands were refactored to allow for more source types being added, the only source type supported currently is HTTP. 

close #76 
close #73
close #72 
close #71 
close #69 

## Type of change

Please delete options that are not relevant.

- [ X ] New feature (non-breaking change which adds functionality)
- [ X ] This change requires a documentation update

# Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation
