### PR TITLE
Updated GetSourcesResponse struct Id from string to int

### DIFF
--- a/api/sources.go
+++ b/api/sources.go
@@ -66,7 +66,7 @@ type CreateSourceResponse struct {
 }
 
 type GetSourcesResponse struct {
-	Id                         string          `json:"id"`
+	Id                         int             `json:"id"`
 	Name                       string          `json:"name"`
 	Category                   string          `json:"category"`
 	HostName                   string          `json:"hostName"`


### PR DESCRIPTION
# Description

This PR fixes a bug when unmarshalling the response from `sumocli sources list`

## Type of change

Please delete options that are not relevant.

- [ X ] New feature (non-breaking change which adds functionality)
- [ X ] This change requires a documentation update

# Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation
