### PR TITLE
Multiple configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # sumocli
-A CLI application that lets you manage/automate your Sumo Logic tenancy. 
+A CLI application that lets you manage/automate your Sumo Logic tenancy.
 
 Sumocli is currently in development so there could be bugs/incomplete functionality.
 GA will be v1.0.0 which I am expecting to be ready for release in Q1 2022.
@@ -51,7 +51,7 @@ Sumocli uses two authentication methods;
 - Environment variables
 - Credentials file
 
-When you run a command in sumocli it will first check to see if a credentials file exists, if it can't find one then it will fall back to environment variables. This is to ensure that sumocli can run in CI/CD pipelines. 
+When you run a command in sumocli it will first check to see if a credentials file exists, if it can't find one then it will fall back to environment variables. This is to ensure that sumocli can run in CI/CD pipelines.
 The sections below explain the requirements for each authentication type.
 
 ### Environment Variables
@@ -64,21 +64,23 @@ SUMO_ACCESS_ID: abcefghi
 SUMO_ACCESS_KEY: AbCeFG123
 
 SUMO_ENDPOINT: https://api.<regioncode>.sumologic.com/api
-```
+```'
 
-For a full list of Sumo Logic regions to API endpoints see this page: 
+Note: Environment variable authentication is not available when using the `sumocli` command.
+
+For a full list of Sumo Logic regions to API endpoints see this page:
 https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
 
 ### Credentials File
 
-The credentials file stores the same information as the environment variables however, it can be generated interactively using `sumocli login`. 
-The Sumo Logic Access ID and Access Key are encrypted (using AES-256) before being written to the credentials file to reduce the risk of the credentials being 
+The credentials file stores the same information as the environment variables however, it can be generated interactively using `sumocli configure`.
+The Sumo Logic Access ID and Access Key are encrypted (using AES-256) before being written to the credentials file to reduce the risk of the credentials being
 used outside of Sumocli.
 
 Encryption of the Sumo Logic Access ID and Access Key was added in v0.9.0 of Sumocli, if you are running
-an earlier version of Sumocli you will need to regenerate your credentials file by running `sumocli login` if you want 
+an earlier version of Sumocli you will need to regenerate your credentials file by running `sumocli configure` if you want
 to leverage encryption at rest.
-If you need to know which Access ID sumocli is configured to use you can run `sumocli login --showAccessId` and
+If you need to know which Access ID sumocli is configured to use you can run `sumocli configure --showAccessId` and
 the plaintext access ID will be displayed.
 
 The credential file is stored in the following locations depending on your operating system.
@@ -91,7 +93,15 @@ Macos: /User/<username>/.sumocli/credentials/creds.json
 Linux: /Usr/<username>/.sumocli/credentials/creds.json
 ```
 
-The contents of the credential file is as follows:
+The credential file path can be changed by supplying the environment variable `SUMO_CONFIG_PATH`.
+
+For example, to create/use a configuration file saved at `.sumocli/credentials/us.json`:
+```
+SUMO_CONFIG_NAME=us sumocli configure
+SUMO_CONFIG_NAME=us sumocli live-tail start
+```
+
+The contents of the credential file is as follows (note that accessid and accesskey are ciphered values):
 
 ```
 {
@@ -111,7 +121,7 @@ You can find a list of API endpoints and sources that Sumocli supports in the [s
 
 ## Contributing
 
-Clone or fork the repo, make your changes and create a pull request. 
+Clone or fork the repo, make your changes and create a pull request.
 I will then review it and all things looking good it gets merged!
 
 If there is something in the code that you don't understand please feel free to email at kyle@thepublicclouds.com.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ SUMO_ACCESS_ID: abcefghi
 SUMO_ACCESS_KEY: AbCeFG123
 
 SUMO_ENDPOINT: https://api.<regioncode>.sumologic.com/api
-```'
+```
 
 Note: Environment variable authentication is not available when using the `sumocli` command.
 

--- a/internal/authentication/authentication.go
+++ b/internal/authentication/authentication.go
@@ -17,16 +17,26 @@ func ConfirmCredentialsSet(client *cip.APIClient) {
 	}
 }
 
-func ConfigPath() string {
-	var filePath = ".sumocli/credentials/creds.json"
+func ConfigName() string {
+	var envConfigName = os.Getenv("SUMO_CONFIG_NAME")
+	if envConfigName != "" {
+		return envConfigName
+	}
+	return "creds"
+}
+
+func ConfigDirPath() string {
 	homeDirectory, _ := os.UserHomeDir()
-	configFile := filepath.Join(homeDirectory, filePath)
-	return configFile
+	return filepath.Join(homeDirectory, ".sumocli/credentials")
+}
+
+func ConfigFilePath() string {
+	return filepath.Join(ConfigDirPath(), ConfigName() + ".json")
 }
 
 func ReadAccessId() string {
-	viper.SetConfigName("creds")
-	viper.AddConfigPath(filepath.Dir(ConfigPath()))
+	viper.SetConfigName(ConfigName())
+	viper.AddConfigPath(ConfigDirPath())
 	viper.AutomaticEnv()
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -45,12 +55,12 @@ func ReadAccessId() string {
 }
 
 func ReadAccessKeys() (string, string, string) {
-	viper.SetConfigName("creds")
-	viper.AddConfigPath(filepath.Dir(ConfigPath()))
+	viper.SetConfigName(ConfigName())
+	viper.AddConfigPath(ConfigDirPath())
 	viper.AutomaticEnv()
 	err := viper.ReadInConfig()
 	if err != nil {
-		fmt.Println("No authentication credentials, please run sumocli login")
+		fmt.Println("No authentication credentials, please run sumocli configure")
 		return "", "", ""
 	} else {
 		version := viper.GetString("version")
@@ -70,8 +80,8 @@ func ReadAccessKeys() (string, string, string) {
 func ReadCredentials() (string, string) {
 	var accessCredentialsComplete string
 	var endpoint string
-	viper.SetConfigName("creds")
-	viper.AddConfigPath(filepath.Dir(ConfigPath()))
+	viper.SetConfigName(ConfigName())
+	viper.AddConfigPath(ConfigDirPath())
 	viper.AutomaticEnv()
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -107,8 +117,8 @@ func ReadCredentials() (string, string) {
 
 func ReadAuthCredentials() (string, string, string) {
 	var endpoint string
-	viper.SetConfigName("creds")
-	viper.AddConfigPath(filepath.Dir(ConfigPath()))
+	viper.SetConfigName(ConfigName())
+	viper.AddConfigPath(ConfigDirPath())
 	viper.AutomaticEnv()
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/pkg/cmd/configure/configure.go
+++ b/pkg/cmd/configure/configure.go
@@ -10,7 +10,6 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -31,7 +30,7 @@ func NewCmdConfigure() *cobra.Command {
 					os.Exit(1)
 				}
 			}
-			configFile := authentication.ConfigPath()
+			configFile := authentication.ConfigFilePath()
 			fmt.Println("Sumocli requires an access id and access key.")
 			fmt.Println("Sumocli will encrypt and store the access id and access key in" +
 				" the following file for use by subsequent commands: " + configFile)
@@ -114,7 +113,7 @@ func getCredentials() {
 		fmt.Printf("Prompt failed %v\n", err)
 	}
 
-	configFilePath := filepath.Dir(authentication.ConfigPath())
+	configFilePath := authentication.ConfigDirPath()
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
 		err := os.MkdirAll(configFilePath, 0755)
 		if err != nil {
@@ -122,11 +121,11 @@ func getCredentials() {
 		}
 	}
 	credentialFile, _ := json.MarshalIndent(credentials, "", "  ")
-	err = os.WriteFile(authentication.ConfigPath(), credentialFile, 0644)
+	err = os.WriteFile(authentication.ConfigFilePath(), credentialFile, 0644)
 	if err != nil {
 		log.Fatal().Err(err)
 	} else {
-		fmt.Println("Credentials file saved to: " + authentication.ConfigPath())
+		fmt.Println("Credentials file saved to: " + authentication.ConfigFilePath())
 	}
 
 	return


### PR DESCRIPTION
# Description

1. Command `sumocli login` seems to have been replaced with `sumocli configure` but docs were not updated
2. Addresses #91 by adding an environment variable to select which configuration name is loaded via viper

Note: Someone from `sumo` should probably build the `sumocli` binary and upload it here...because I wouldn't trust me.

## Before

Command `sumocli login` is in the docs but `sumocli configure` is used

Configuration was hardcoded to `creds`

## After

Command `sumocli configure` is in the docs and `sumocli configure` is used

Configuration is determined by `env["SUMO_CONFIG_NAME"] || "creds"`

## Type of change

Please delete options that are not relevant.

- [y] New feature (non-breaking change which adds functionality)
- [n] This change requires a documentation update

# Checklist:

- [y] My code follows the style guidelines of this project
- [y] I have performed a self-review of my own code
- [y] I have commented my code, particularly in hard-to-understand areas
- [y] I have made corresponding changes to the documentation
